### PR TITLE
fix: Add install requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,8 @@ setup(
     packages=find_packages(),
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
+    install_requires=[
+        "celery==5.3.4",
+        "urllib3<2.0"
+    ],
 )


### PR DESCRIPTION
This pull request aims to enhance the project's compatibility and ease of installation across different environments by including the install_requires section in the setup.py file. The motivation behind this is to provide a seamless installation experience for users who might not have pipenv installed or prefer to use other tools for package management.

By mirroring the dependencies listed in the Pipfile to the install_requires section of setup.py, users will be able to install the package using traditional pip commands without the need for additional tools.

Changes Made:

Added install_requires in setup.py based on the dependencies listed in the Pipfile.
Ensured consistency in dependency versions between the two files.

Testing:
Include import of commit with this chage, in outside requirements.txt, and run pip install -r requirements.txt of this outside app:


hijiki @ git+https://github.com/asengardeon/hijiki.git@07d0587137793fbf0a8b7597245e6be22703df4e