### PR TITLE
fix: Fix setup wheel dependencie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     packages=find_packages(),
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
+    setup_requires=['wheel'],
     install_requires=[
         "celery==5.3.4",
         "urllib3<2.0"


### PR DESCRIPTION
Summary:
Resolve the "invalid command 'bdist_wheel'" issue encountered during the python setup.py bdist_wheel command execution. This error is caused by the absence of the 'wheel' library in the Pipenv environment.

Changes Made:

Added 'wheel' to the setup_requires section in setup.py to ensure it is installed before running bdist_wheel.