### PR TITLE
Added  cluster connection support to Publisher and Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,35 @@ Python Rabbit wrapper library to simplify to use Exchanges and Queues with decor
 ## Configurations
 Hijiki uses environment variables to configure connection with BROKER. 
 
-- BROKER_PORT
+### COMMON
 - BROKER_PWD
 - BROKER_USERNAME
+
+### For single server
+- BROKER_PORT
 - BROKER_SERVER
 
-If server is not present the connection url will be a default, and to others configs will be changed for "teste".
+### For cluster server
+- BROKER_CLUSTER_SERVER
+
+if BROKER_CLUSTER_SERVER is present the priority is generate URI using this list of servers, and not use the sever for single server. 
+To user multiples server from cluster is necessary this environment variable has a list of server with port separates with comma. 
+
+Ex: 
+```
+serverA:5672,serverB:5673
+
+```
+generating for uri connection string the value above
+
+``
+amqp://usr:password@server:5672;amqp://usr:password@serverB:5672;
+``
+
+The user and password is the same for all servers.
+
+
+If server is not present, even BROKER_CLUSTER_SERVER, the connection url will be a default, and to others configs will be changed for "teste".
 
 ## How to use
 ### Publisher

--- a/hijiki/broker/broker_data.py
+++ b/hijiki/broker/broker_data.py
@@ -4,17 +4,37 @@ BROKER_PORT = "BROKER_PORT"
 BROKER_PWD = "BROKER_PWD"
 BROKER_USERNAME = "BROKER_USERNAME"
 BROKER_SERVER = "BROKER_SERVER"
+BROKER_CLUSTER_SERVER = "BROKER_CLUSTER_SERVER"
+
+
+def __build_cluster_uri(cluster_server: str, username: str, pwd: str):
+    servers = cluster_server.split(',')
+    uri = ""
+    for s in servers:
+        uri += f'amqp://{username}:{pwd}@{s};'
+    return uri
 
 
 def get_broker_url():
+    cluster_server = os.environ[BROKER_CLUSTER_SERVER] if BROKER_CLUSTER_SERVER in os.environ else None
     server = os.environ[BROKER_SERVER] if BROKER_SERVER in os.environ else None
     username = os.environ[BROKER_USERNAME] if BROKER_USERNAME in os.environ else None
     pwd = os.environ[BROKER_PWD] if BROKER_PWD in os.environ else None
     port = os.environ[BROKER_PORT] if BROKER_PORT in os.environ else "5672"
-    return f'amqp://{username}:{pwd}@{server}:{port}' if server else 'amqp://rabbitmq:rabbitmq@localhost:5672'
+    if cluster_server:
+        return __build_cluster_uri(cluster_server, username, pwd)
+    else:
+        return f'amqp://{username}:{pwd}@{server}:{port}' if server else 'amqp://rabbitmq:rabbitmq@localhost:5672'
 
-def init_os_environ(host, username, password, port):
-    os.environ[BROKER_SERVER] = host
-    os.environ[BROKER_USERNAME] = username
-    os.environ[BROKER_PWD] = password
-    os.environ[BROKER_PORT] = str(port)
+
+def init_os_environ(host, username, password, port, cluster_servers):
+    if cluster_servers:
+        os.environ[BROKER_CLUSTER_SERVER] = cluster_servers
+    if host:
+        os.environ[BROKER_SERVER] = host
+    if username:
+        os.environ[BROKER_USERNAME] = username
+    if password:
+        os.environ[BROKER_PWD] = password
+    if port:
+        os.environ[BROKER_PORT] = str(port)

--- a/hijiki/broker/hijiki_broker.py
+++ b/hijiki/broker/hijiki_broker.py
@@ -16,13 +16,9 @@ class HijikiBroker:
             dead_letter_queue = Queue(f'dlq_{name}', dlx, routing_key='*', queue_arguments={'x-queue-type': 'quorum'})
             dead_letter_queue.bind(self.celery_broker.broker_connection()).declare()
 
-    def __init__(self, app_name, host, username, password, port):
-        init_os_environ(host, username, password, port)
+    def __init__(self, app_name, host, username, password, port, cluster_hosts):
+        init_os_environ(host, username, password, port, cluster_hosts)
         self.celery_broker = Celery(app_name, broker=get_broker_url(), set_as_current=True)
-
 
     def get_celery_broker(self):
         return self.celery_broker
-
-    def bind_queues(self, queues_names):
-        self.bind_queues(queues_names)

--- a/hijiki/broker/hijiki_broker.py
+++ b/hijiki/broker/hijiki_broker.py
@@ -1,20 +1,10 @@
-import os
-
 from celery import Celery
-from kombu import Exchange, Queue
 
 from hijiki.broker.broker_data import get_broker_url, init_os_environ
 
 
 class HijikiBroker:
     celery_broker = None
-
-    def bind_queues(self, queues_names):
-        for name in queues_names:
-            dlx = Exchange(f'dlq_{name}_exchange', type='topic')
-
-            dead_letter_queue = Queue(f'dlq_{name}', dlx, routing_key='*', queue_arguments={'x-queue-type': 'quorum'})
-            dead_letter_queue.bind(self.celery_broker.broker_connection()).declare()
 
     def __init__(self, app_name, host, username, password, port, cluster_hosts):
         init_os_environ(host, username, password, port, cluster_hosts)

--- a/hijiki/broker/hijiki_rabbit.py
+++ b/hijiki/broker/hijiki_rabbit.py
@@ -28,6 +28,7 @@ class HijikiRabbit():
         self.username = None
         self.queue_exchanges = None
         self.worker = None
+        self.port = None
 
     def terminate(self):
         self.worker.should_stop = True

--- a/hijiki/broker/hijiki_rabbit.py
+++ b/hijiki/broker/hijiki_rabbit.py
@@ -1,4 +1,4 @@
-from functools import wraps, partial, partialmethod
+from functools import wraps, partial
 from typing import List
 
 from kombu import Queue, Exchange
@@ -7,18 +7,26 @@ from kombu.common import logger
 from hijiki.broker.hijiki_broker import HijikiBroker
 from hijiki.decorator.worker import Worker
 
+
 class HijikiQueueExchange():
     def __init__(self, name, exchange_name):
         self.name = name
         self.exchange_name = exchange_name
 
-class HijikiRabbit():
 
+class HijikiRabbit():
     queues = {}
     callbacks = {}
     _prefix = ""
 
     def __init__(self):
+        self.connection = None
+        self.broker = None
+        self.host = None
+        self.cluster_hosts = None
+        self.password = None
+        self.username = None
+        self.queue_exchanges = None
         self.worker = None
 
     def terminate(self):
@@ -35,8 +43,13 @@ class HijikiRabbit():
     def with_password(self, password: str):
         self.password = password
         return self
+
     def with_host(self, host: str):
         self.host = host
+        return self
+
+    def with_cluster_hosts(self, hosts: str):
+        self.cluster_hosts = hosts
         return self
 
     def with_port(self, port: str):
@@ -44,7 +57,7 @@ class HijikiRabbit():
         return self
 
     def build(self):
-        self.broker = HijikiBroker('worker', self.host, self.username, self.password, self.port)
+        self.broker = HijikiBroker('worker', self.host, self.username, self.password, self.port, self.cluster_hosts)
         self.connection = self.broker.get_celery_broker().broker_connection()
         self.init_queues()
         return self
@@ -66,19 +79,19 @@ class HijikiRabbit():
             queue = Queue(name,
                           task_exchange,
                           routing_key=routing_key,
-                          queue_arguments={'x-queue-type': 'quorum','x-dead-letter-exchange': f'{q.exchange_name}_dlq', 'x-delivery-limit': 10})
+                          queue_arguments={'x-queue-type': 'quorum', 'x-dead-letter-exchange': f'{q.exchange_name}_dlq',
+                                           'x-delivery-limit': 10})
 
             queue.bind(self.connection).declare()
 
             queue_dlq = Queue(f'{name}_dlq',
-                          task_exchange_dlq,
-                          routing_key=routing_key,
-                          queue_arguments={'x-queue-type': 'quorum'})
+                              task_exchange_dlq,
+                              routing_key=routing_key,
+                              queue_arguments={'x-queue-type': 'quorum'})
 
             queue_dlq.bind(self.connection).declare()
 
             self.queues[name].append(queue)
-
 
     def _wrap_function(self, function, callback, queue_name, task=False):
 
@@ -93,7 +106,9 @@ class HijikiRabbit():
             @wraps(func)
             def wrapper(*args, **kwargs):
                 pass
+
             return wrapper
+
         return decorate
 
     def task(self, func=None, *, queue_name=None):
@@ -120,7 +135,6 @@ class HijikiRabbit():
 
         return self._wrap_function(
             func, process_message, queue_name, task=True)
-
 
     def run(self):
         try:

--- a/hijiki/publisher/Publisher.py
+++ b/hijiki/publisher/Publisher.py
@@ -5,8 +5,8 @@ from hijiki.broker.hijiki_broker import HijikiBroker
 
 class Publisher():
 
-    def __init__(self, host, username, password, port):
-        self.client = HijikiBroker('client', host, username, password, port)
+    def __init__(self, host, username, password, port, cluster_hosts: str = None):
+        self.client = HijikiBroker('client', host, username, password, port, cluster_hosts)
 
     def publish_message(self, event_name: str, data: str):
         payload = {"value": data}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,0 +1,35 @@
+import threading
+
+from hijiki.broker.hijiki_rabbit import HijikiQueueExchange, HijikiRabbit
+
+result_event_list = []
+
+class Runner():
+    qs = [HijikiQueueExchange('teste1', 'teste1_event'), HijikiQueueExchange('teste2', 'teste2_event')]
+    gr = HijikiRabbit().with_queues_exchange(qs) \
+        .with_username("user") \
+        .with_password("pwd") \
+        .with_host("localhost") \
+        .with_port(5672) \
+        .build()
+
+    threads = []
+
+    @gr.task(queue_name="teste1")
+    def internal_consumer(data):
+        print(f"consumiu o valor:{data}")
+        result_event_list.append('recebeu evento')
+
+    def run(self):
+        t = threading.Thread(target=self.gr.run)
+        self.threads.append(t)
+        t.start()
+
+    def stop(self):
+        self.gr.terminate()
+
+    def __del__(self):
+        super()
+
+    def get_results(self):
+        return result_event_list

--- a/tests/test_broker_data_server_exists.py
+++ b/tests/test_broker_data_server_exists.py
@@ -26,17 +26,14 @@ class TestMyModule(unittest.TestCase):
         self.assertEqual(get_broker_url(), 'amqp://None:None@teste:5672')
 
     def test_broker_server_env_exists_in_environment_variable(self):
-        self.assertEqual(get_broker_url(), 'amqp://None:None@teste:5672')
-
-    def test_broker_server_env_exists_in_environment_variable(self):
-        self.assertEqual(get_broker_url(), 'amqp://None:None@teste:5672')
+        self.assertEqual('amqp://None:None@teste:5672', get_broker_url())
 
     def test_alldata_env_exists_in_environment_variable(self):
         os.environ[BROKER_SERVER] = 'server'
         os.environ[BROKER_USERNAME] = 'usr'
         os.environ[BROKER_PWD] = 'password'
         os.environ[BROKER_PORT] = '5427'
-        self.assertEqual(get_broker_url(), 'amqp://usr:password@server:5427')
+        self.assertEqual( 'amqp://usr:password@server:5427', get_broker_url())
 
 
     def test_broker_cluster_server_env_exists_in_environment_variable(self):

--- a/tests/test_broker_data_server_exists.py
+++ b/tests/test_broker_data_server_exists.py
@@ -1,7 +1,9 @@
 import os
 import unittest
 
-from hijiki.broker.broker_data import get_broker_url, BROKER_SERVER, BROKER_USERNAME, BROKER_PWD, BROKER_PORT
+from hijiki.broker.broker_data import get_broker_url, BROKER_SERVER, BROKER_USERNAME, BROKER_PWD, BROKER_PORT, \
+    BROKER_CLUSTER_SERVER
+
 
 class TestMyModule(unittest.TestCase):
 
@@ -12,6 +14,7 @@ class TestMyModule(unittest.TestCase):
         os.environ.pop(BROKER_USERNAME) if os.environ.get(BROKER_USERNAME) else None
         os.environ.pop(BROKER_PWD) if os.environ.get(BROKER_PWD) else None
         os.environ.pop(BROKER_PORT) if os.environ.get(BROKER_PORT) else None
+        os.environ.pop(BROKER_CLUSTER_SERVER) if os.environ.get(BROKER_CLUSTER_SERVER) else None
 
     def test_broker_username_env_not_exists_in_environment_variable_but_server_exists(self):
         self.assertEqual(get_broker_url(), 'amqp://None:None@teste:5672')
@@ -34,3 +37,22 @@ class TestMyModule(unittest.TestCase):
         os.environ[BROKER_PWD] = 'password'
         os.environ[BROKER_PORT] = '5427'
         self.assertEqual(get_broker_url(), 'amqp://usr:password@server:5427')
+
+
+    def test_broker_cluster_server_env_exists_in_environment_variable(self):
+        os.environ[BROKER_CLUSTER_SERVER] = 'server:5672'
+        self.assertEqual('amqp://None:None@server:5672;', get_broker_url())
+
+    def test_multiples_broker_cluster_server_env_exists_in_environment_variable(self):
+        os.environ[BROKER_CLUSTER_SERVER] = 'server:5672,serverB:5672'
+        self.assertEqual('amqp://None:None@server:5672;amqp://None:None@serverB:5672;', get_broker_url())
+
+    def test_broker_cluster_server_env_exists_in_environment_variable_and_single_server_exists(self):
+        os.environ[BROKER_CLUSTER_SERVER] = 'server:5672,serverB:5672'
+        os.environ[BROKER_SERVER] = 'singleserver'
+        os.environ[BROKER_USERNAME] = 'usr'
+        os.environ[BROKER_PWD] = 'password'
+        os.environ[BROKER_PORT] = '5427'
+        self.assertEqual('amqp://usr:password@server:5672;amqp://usr:password@serverB:5672;', get_broker_url())
+
+

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -1,39 +1,8 @@
-import threading
 import time
 import unittest
 
-from hijiki.broker.hijiki_rabbit import HijikiQueueExchange, HijikiRabbit
 from hijiki.publisher.Publisher import Publisher
-
-result_event_list = []
-
-
-class Runner():
-    qs = [HijikiQueueExchange('teste1', 'teste1_event'), HijikiQueueExchange('teste2', 'teste2_event')]
-    gr = HijikiRabbit().with_queues_exchange(qs) \
-        .with_username("user") \
-        .with_password("pwd") \
-        .with_host("localhost") \
-        .with_port(5672) \
-        .build()
-
-    threads = []
-
-    @gr.task(queue_name="teste1")
-    def internal_consumer(data):
-        print(f"consumiu o valor:{data}")
-        result_event_list.append('recebeu evento')
-
-    def run(self):
-        t = threading.Thread(target=self.gr.run)
-        self.threads.append(t)
-        t.start()
-
-    def stop(self):
-        self.gr.terminate()
-
-    def __del__(self):
-        super()
+from tests.runner import Runner
 
 
 class TestPublisherConsumer(unittest.TestCase):
@@ -56,4 +25,4 @@ class TestPublisherConsumer(unittest.TestCase):
         time.sleep(5)
         self.pub.publish_message('teste1_event', '{"value": "Esta é a mensagem"}')
         time.sleep(1)
-        self.assertEqual(len(result_event_list), 1)
+        self.assertEqual(len(self.runner.get_results()), 1)


### PR DESCRIPTION
Summary:
In some environments the connection to Rabbit is a Cluster. This project is based in celery and the conenction on cluster are URIs, separated by semicolon;

Changes Made:

Added a new param to connection on Publisher object, Environment Variable named BROKER_CLUSTER_SERVER, and changes in builder to support cluster connections.
This values above are strings that receive server with ports, separated by comma.
EX: serverA:5672,serverB:5672