### PR TITLE
Fixed Behavior to runner considerer errors in consumer to requeue mes…

### DIFF
--- a/hijiki/broker/hijiki_rabbit.py
+++ b/hijiki/broker/hijiki_rabbit.py
@@ -23,7 +23,7 @@ class HijikiRabbit():
         self.connection = None
         self.broker = None
         self.host = None
-        self.cluster_hosts = None
+        self.cluster_hosts = []
         self.password = None
         self.username = None
         self.queue_exchanges = None
@@ -50,7 +50,7 @@ class HijikiRabbit():
         return self
 
     def with_cluster_hosts(self, hosts: str):
-        self.cluster_hosts = hosts
+        self.cluster_hosts.append(hosts)
         return self
 
     def with_port(self, port: str):
@@ -128,8 +128,9 @@ class HijikiRabbit():
                                                  body))
             try:
                 func(body)
-            except Exception:
+            except Exception as e:
                 logger.error("Problem processing task", exc_info=True)
+                message.requeue()
             else:
                 logger.debug("Ack'ing message.")
                 message.ack()

--- a/tests/manual_execution_any_test.py
+++ b/tests/manual_execution_any_test.py
@@ -1,0 +1,20 @@
+from hijiki.publisher.Publisher import Publisher
+from tests.runner import Runner
+
+
+class ExecutaDebugger():
+
+    def __init__(self):
+        self.runner = Runner()
+        self.runner.run()
+        self.pub = Publisher("localhost", "user", "pwd", 5672)
+
+
+    def executar(self):
+        self.pub = Publisher("localhost", "user", "pwd", 5672)
+        self.pub.publish_message('erro_event', '{"value": "Esta é a mensagem"}')
+
+
+if __name__ == '__main__':
+    e = ExecutaDebugger()
+    e.executar()

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -5,7 +5,8 @@ from hijiki.broker.hijiki_rabbit import HijikiQueueExchange, HijikiRabbit
 result_event_list = []
 
 class Runner():
-    qs = [HijikiQueueExchange('teste1', 'teste1_event'), HijikiQueueExchange('teste2', 'teste2_event')]
+    qs = [HijikiQueueExchange('teste1', 'teste1_event'),
+          HijikiQueueExchange('fila_erro', 'erro_event')]
     gr = HijikiRabbit().with_queues_exchange(qs) \
         .with_username("user") \
         .with_password("pwd") \
@@ -19,6 +20,12 @@ class Runner():
     def internal_consumer(data):
         print(f"consumiu o valor:{data}")
         result_event_list.append('recebeu evento')
+
+    @gr.task(queue_name="fila_erro")
+    def internal_consumer(data):
+        print(f"consumiu o valor:{data}")
+        result_event_list.append('recebeu evento')
+        raise Exception("falhou")
 
     def run(self):
         t = threading.Thread(target=self.gr.run)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -38,5 +38,8 @@ class Runner():
     def __del__(self):
         super()
 
+    def clear_results(self):
+        result_event_list.clear()
+
     def get_results(self):
         return result_event_list

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -4,12 +4,14 @@ import unittest
 from hijiki.publisher.Publisher import Publisher
 from tests.runner import Runner
 
+DLQ_RETRY_NUMBER = 11 # At eleven interaction the message goes to the Dead Letter Queue
+SECS_TO_AWAIT_BROKER = 5
+
 
 class TestPublisherConsumer(unittest.TestCase):
     runner = None
 
     def setUp(self):
-        result_event_list = []
         self.runner = Runner()
         self.runner.run()
         self.pub = Publisher("localhost", "user", "pwd", 5672)
@@ -22,7 +24,16 @@ class TestPublisherConsumer(unittest.TestCase):
 
     def test_consume_a_message(self):
         self.pub = Publisher("localhost", "user", "pwd", 5672)
-        time.sleep(5)
+        time.sleep(SECS_TO_AWAIT_BROKER)
         self.pub.publish_message('teste1_event', '{"value": "Esta é a mensagem"}')
-        time.sleep(1)
+        time.sleep(SECS_TO_AWAIT_BROKER)
         self.assertEqual(len(self.runner.get_results()), 1)
+
+    def test_consume_a_message_failed(self):
+        self.pub = Publisher("localhost", "user", "pwd", 5672)
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.pub.publish_message('erro_event', '{"value": "Esta é a mensagem"}')
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertEqual(DLQ_RETRY_NUMBER, len(self.runner.get_results()))
+
+

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -20,9 +20,11 @@ class TestPublisherConsumer(unittest.TestCase):
         self.runner.stop()
 
     def test_publish_a_message(self):
+        self.runner.clear_results()
         self.pub.publish_message('teste1_event', '{"value": "Esta é a mensagem"}')
 
     def test_consume_a_message(self):
+        self.runner.clear_results()
         self.pub = Publisher("localhost", "user", "pwd", 5672)
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.pub.publish_message('teste1_event', '{"value": "Esta é a mensagem"}')
@@ -30,6 +32,7 @@ class TestPublisherConsumer(unittest.TestCase):
         self.assertEqual(len(self.runner.get_results()), 1)
 
     def test_consume_a_message_failed(self):
+        self.runner.clear_results()
         self.pub = Publisher("localhost", "user", "pwd", 5672)
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.pub.publish_message('erro_event', '{"value": "Esta é a mensagem"}')

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -25,7 +25,6 @@ class TestPublisherConsumer(unittest.TestCase):
 
     def test_consume_a_message(self):
         self.runner.clear_results()
-        self.pub = Publisher("localhost", "user", "pwd", 5672)
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.pub.publish_message('teste1_event', '{"value": "Esta é a mensagem"}')
         time.sleep(SECS_TO_AWAIT_BROKER)
@@ -33,7 +32,6 @@ class TestPublisherConsumer(unittest.TestCase):
 
     def test_consume_a_message_failed(self):
         self.runner.clear_results()
-        self.pub = Publisher("localhost", "user", "pwd", 5672)
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.pub.publish_message('erro_event', '{"value": "Esta é a mensagem"}')
         time.sleep(SECS_TO_AWAIT_BROKER)


### PR DESCRIPTION
**Problem:**
When a consumer raises a exception, the message has been stay at queue, but wasn't consume by another, or the same, consumer, staying in the queue forever or when a consumer had been initiated again.

**The Error:**
IN the library, when a message wa consumed with sucess, the message has been marked as ACK, but in error wasnt marked to requeue.

**The Fix:**
On error, the lib calls message.requeued to mak the message as NACK.