### PR TITLE
Adicionar função para realizar ping

### DIFF
--- a/hijiki/broker/hijiki_rabbit.py
+++ b/hijiki/broker/hijiki_rabbit.py
@@ -23,7 +23,7 @@ class HijikiRabbit():
         self.connection = None
         self.broker = None
         self.host = None
-        self.cluster_hosts = []
+        self.cluster_hosts = None
         self.password = None
         self.username = None
         self.queue_exchanges = None
@@ -50,12 +50,15 @@ class HijikiRabbit():
         return self
 
     def with_cluster_hosts(self, hosts: str):
-        self.cluster_hosts.append(hosts)
+        self.cluster_hosts = hosts
         return self
 
     def with_port(self, port: str):
         self.port = port
         return self
+
+    def ping(self):
+        return self.broker.ping()
 
     def build(self):
         self.broker = HijikiBroker('worker', self.host, self.username, self.password, self.port, self.cluster_hosts)
@@ -98,7 +101,7 @@ class HijikiRabbit():
             self.queues[name + "_dlq"].append(queue_dlq)
 
     def _wrap_function(self, function, callback, queue_name, task=False):
-        
+
         self.callbacks[queue_name].append(callback)
 
         # The function returned by the decorator don't really do
@@ -143,7 +146,7 @@ class HijikiRabbit():
 
     def run(self):
         consumers_without_callbacks = [
-            key 
+            key
             for (key, callbacks) in self.callbacks.items()
             if not callbacks
         ]

--- a/tests/test_broker_ping.py
+++ b/tests/test_broker_ping.py
@@ -1,0 +1,26 @@
+import unittest
+
+from hijiki.broker.hijiki_broker import HijikiBroker
+from tests.runner import Runner
+
+DLQ_RETRY_NUMBER = 11 # At eleven interaction the message goes to the Dead Letter Queue
+SECS_TO_AWAIT_BROKER = 5
+
+
+class TestBrokerPing(unittest.TestCase):
+    runner = None
+
+    def setUp(self):
+        self.runner = Runner()
+        self.runner.run()
+
+    def tearDown(self):
+        self.runner.stop()
+
+    def test_success_ping(self):
+        broker = HijikiBroker("worker", "localhost", "user", "pwd", 5672, None)
+        self.assertTrue(broker.ping())
+
+    def test_fail_ping(self):
+        broker = HijikiBroker("worker", "localhost", "user", "wrong_pwd", 5672, None)
+        self.assertFalse(broker.ping())


### PR DESCRIPTION
## Contexto
Estamos adicionando uma função ao HijikBroker para que ele seja capaz de testar sua conexão ao rabbitmq

## Teste
- Inicie o HijikBroker com o docker compose rodando
- Chame a função ping e veja que o retorno é True
- Pare o docker
- Chame a função ping e veja que o retorno é False