### PR TITLE
Feature: Permitir o envio de mensagens em diferentes patrões

### DIFF
--- a/hijiki/publisher/Publisher.py
+++ b/hijiki/publisher/Publisher.py
@@ -1,8 +1,12 @@
-from typing import Optional
+from typing import Optional, Callable
 
 from kombu import producers, Exchange
 
 from hijiki.broker.hijiki_broker import HijikiBroker
+
+
+def default_message_mapper(_: str, data: str):
+    return {"value": data}
 
 
 class Publisher():
@@ -10,11 +14,8 @@ class Publisher():
     def __init__(self, host, username, password, port, cluster_hosts: str = None, heartbeat: Optional[float] = 60):
         self.client = HijikiBroker('client', host, username, password, port, cluster_hosts, heartbeat=heartbeat)
 
-    def publish_message(self, event_name: str, data: str, nest_patter: bool = False):
-        if nest_patter:
-            payload = {"data": data, "pattern": event_name}
-        else:
-            payload = {"value": data}
+    def publish_message(self, event_name: str, data: str, message_mapper: Callable[[str, str], dict] = default_message_mapper):
+        payload = message_mapper(event_name, data)
 
         connection = self.client.get_celery_broker().broker_connection(heartbeat=self.client.heartbeat)
         with producers[connection].acquire(block=True) as producer:

--- a/hijiki/publisher/Publisher.py
+++ b/hijiki/publisher/Publisher.py
@@ -10,8 +10,12 @@ class Publisher():
     def __init__(self, host, username, password, port, cluster_hosts: str = None, heartbeat: Optional[float] = 60):
         self.client = HijikiBroker('client', host, username, password, port, cluster_hosts, heartbeat=heartbeat)
 
-    def publish_message(self, event_name: str, data: str):
-        payload = {"value": data}
+    def publish_message(self, event_name: str, data: str, nest_patter: bool = False):
+        if nest_patter:
+            payload = {"data": data, "pattern": event_name}
+        else:
+            payload = {"value": data}
+
         connection = self.client.get_celery_broker().broker_connection(heartbeat=self.client.heartbeat)
         with producers[connection].acquire(block=True) as producer:
             task_exchange = Exchange(event_name, type='topic')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -3,6 +3,7 @@ import threading
 from hijiki.broker.hijiki_rabbit import HijikiQueueExchange, HijikiRabbit
 
 result_event_list = []
+result_data_list = []
 result_event_list_dlq = []
 
 class Runner():
@@ -25,8 +26,9 @@ class Runner():
     @gr.task(queue_name="teste1")
     def internal_consumer(data):
         print(f"consumiu o valor:{data}")
+        result_data_list.append(data)
         result_event_list.append('received event')
-    
+
     @gr.task(queue_name="teste1_dlq")
     def internal_consumer_dlq(data):
         print(f"consumiu o valor:{data}")
@@ -42,10 +44,11 @@ class Runner():
     def internal_consumer_erro_dlq(data):
         print(f"consumiu o valor:{data}")
         result_event_list_dlq.append('received event')
-    
+
     @gr.task(queue_name="without_dlq")
     def internal_consumer_extra(data):
         print(f"consumiu o valor:{data}")
+        result_data_list.append(data)
         result_event_list.append('received event')
         raise Exception("falhou")
 
@@ -63,13 +66,14 @@ class Runner():
 
     def clear_results(self):
         result_event_list.clear()
+        result_data_list.clear()
         result_event_list_dlq.clear()
 
     def get_results(self):
         return result_event_list
 
-    def get_results(self):
-        return result_event_list
+    def get_results_data(self):
+        return result_data_list
 
     def get_results_dlq(self):
         return result_event_list_dlq

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -32,16 +32,19 @@ class TestPublisherConsumer(unittest.TestCase):
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.assertEqual(len(self.runner.get_results()), 1)
 
-    def test_publish_a_message_nest_patter(self):
+    def test_consume_a_message_with_other_mapper(self):
         self.runner.clear_results()
-        self.pub.publish_message('teste1_event', '{"value": "This is the message"}', nest_patter=True)
+        def other_message_mapper(event_name: str, data: str):
+            return {"other_key": data, "event_name": event_name}
 
-    def test_consume_a_message_nest_patter(self):
-        self.runner.clear_results()
+        event_name = 'teste1_event'
+        message = '{"value": "This is the message"}'
         time.sleep(SECS_TO_AWAIT_BROKER)
-        self.pub.publish_message('teste1_event', '{"value": "This is the message"}', nest_patter=True)
+        self.pub.publish_message(event_name, message, message_mapper=other_message_mapper)
         time.sleep(SECS_TO_AWAIT_BROKER)
-        self.assertEqual(len(self.runner.get_results()), 1)
+        self.assertEqual(self.runner.get_results_data(), [
+            {"other_key": message, "event_name": event_name}
+        ])
 
     def test_consume_a_message_failed(self):
         self.runner.clear_results()

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -32,6 +32,17 @@ class TestPublisherConsumer(unittest.TestCase):
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.assertEqual(len(self.runner.get_results()), 1)
 
+    def test_publish_a_message_nest_patter(self):
+        self.runner.clear_results()
+        self.pub.publish_message('teste1_event', '{"value": "This is the message"}', nest_patter=True)
+
+    def test_consume_a_message_nest_patter(self):
+        self.runner.clear_results()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.pub.publish_message('teste1_event', '{"value": "This is the message"}', nest_patter=True)
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertEqual(len(self.runner.get_results()), 1)
+
     def test_consume_a_message_failed(self):
         self.runner.clear_results()
         time.sleep(SECS_TO_AWAIT_BROKER)


### PR DESCRIPTION
## Contexto

Serviços feitos em outros frameworks podem esperar que as mensagens sigam um padrão específico, nesse PR adicionamos uma função de mapper para permitir o envio de mensagens em outros padrões