### PR TITLE
bugfix: Faz com que o término de conexões do Rabbit ocorra de forma thread-safe

### DIFF
--- a/hijiki/adapters/rabbitmq_adapter.py
+++ b/hijiki/adapters/rabbitmq_adapter.py
@@ -19,13 +19,15 @@ class RabbitMQAdapter:
     def stop_consuming(self):
         if self.channel.is_open:
             self.channel.close()
+        if self.rabbit_connection and self.rabbit_connection.is_open:
+            self.rabbit_connection.close()
 
 
     def ping(self):
         """Verifica se a conexão está ativa."""
         result = False
         try:
-            if self.rabbit_connection and self.rabbit_connection.is_open():
+            if self.rabbit_connection and self.rabbit_connection.is_open:
                 self.rabbit_connection.process_data_events()
                 result = True
         except Exception as e:

--- a/hijiki/adapters/rabbitmq_consumer_adapter.py
+++ b/hijiki/adapters/rabbitmq_consumer_adapter.py
@@ -15,7 +15,6 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
         self.auto_ack = consumer_data.auto_ack
         self.routing_key = consumer_data.routing_key if consumer_data.routing_key else "*"
         self._consumer_thread = None
-        self._stop_event = threading.Event()
         self.create_dlq = consumer_data.create_dlq
 
 
@@ -59,9 +58,6 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
                 logging.error(f"Erro ao processar mensagem: {e}")
                 if not self.auto_ack:
                     ch.basic_reject(delivery_tag=method.delivery_tag, requeue=True)
-            finally:
-                if self._stop_event.is_set():
-                    self.get_channel().stop_consuming()
 
         try:
             self.get_channel().basic_consume(queue=self.queue, on_message_callback=callback)
@@ -72,7 +68,6 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
             raise e
 
     def consume(self):
-        self._stop_event.clear()
         self.connect()
         self.create_exchange_and_queue()
         """Inicia o consumo da fila em uma thread separada."""
@@ -91,8 +86,6 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
                 self.get_channel().stop_consuming()
 
         if self._consumer_thread and self._consumer_thread.is_alive():
-            self._stop_event.set()
-
             if self.rabbit_connection and self.rabbit_connection.is_open:
                 self.rabbit_connection.add_callback_threadsafe(_stop_consuming)
 

--- a/tests/test_mesage_manager.py
+++ b/tests/test_mesage_manager.py
@@ -1,11 +1,17 @@
+import time
 import unittest
+import pytest
 from unittest.mock import Mock
 
+from hijiki.adapters.rabbitmq_broker import RabbitMQBroker
 from hijiki.config.consumer_data import ConsumerData
+from hijiki.connection.rabbitmq_connection import ConnectionParameters
+from hijiki.manager.message_manager_builder import MessageManagerBuilder
 from hijiki.ports.message_broker import MessageBroker
 from hijiki.manager.message_manager import MessageManager
 import json
 
+SECS_TO_AWAIT_BROKER = 2
 
 def _other_message_mapper(event_name: str, data: str):
     return {"other_key": data, "event_name": event_name}
@@ -44,3 +50,19 @@ class TestMessageManager(unittest.TestCase):
     def test_start_consuming(self):
         self.manager.start_consuming()
         self.broker_mock.start_consuming.assert_called()
+
+    def test_stop_consuming_rabbitmq_running_consumer(self):
+        connection_params = ConnectionParameters("localhost", 5672, "user", "pwd")
+        actual_broker = RabbitMQBroker(connection_params)
+        manager = MessageManager(actual_broker)
+
+        consumer_data = ConsumerData("test_queue", "test_topic", lambda x: x)
+        manager.create_consumer(consumer_data)
+
+        manager.start_consuming()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertTrue(manager.is_alive())
+
+        manager.stop_consuming()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertFalse(manager.is_alive())


### PR DESCRIPTION
# Contexto

Ao atualizar a lib da v1 para v2 em um projeto, tive alguns problemas com o teardown de consumidores ao ajustar os testes automatizados do projeto.

Na configuração de testes do meu projeto, alguns casos de testes sobem um consumidor do RabbitMQ de fato, utilizando a lib pra isso. Uma vez que esse consumidor não é mais necessário, para que ele seja encerrado da forma adequada, chamamos as funções da lib (como o `MessageManager.stop_consuming()`).

Após ajustar todos os testes para que eles passassem, embora todos os testes fossem bem sucedidos, todos apresentavam um erro durante o teardown, com um log como o seguinte:

```console
========================================================================================== ERRORS ===========================================================================================
______________________________________ ERROR at teardown of <nome-do-teste> ______________________________________

(...)

E                   pika.exceptions.StreamLostError: Stream connection lost: IndexError('pop from an empty deque')

.venv/lib/python3.13/site-packages/pika/adapters/blocking_connection.py:523: StreamLostError

(...)

----------------------------------------------------------------------------------- Captured log teardown -----------------------------------------------------------------------------------
ERROR    pika.adapters.utils.io_services_utils:io_services_utils.py:1109 _AsyncBaseTransport._produce() failed, aborting connection: error=IndexError('pop from an empty deque'); sock=<socket.socket fd=21, family=30, type=1, proto=6, laddr=('::1', 54887, 0, 0), raddr=('::1', 5672, 0, 0)>; Caller's stack:
Traceback (most recent call last):
  File "/Users/ikedaleo/work/geekie/geekie-custom-study-data/.venv/lib/python3.13/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
    ~~~~~~~~~~~~~^^
  File "/Users/ikedaleo/work/geekie/geekie-custom-study-data/.venv/lib/python3.13/site-packages/pika/adapters/utils/io_services_utils.py", line 822, in _produce
    chunk = self._tx_buffers.popleft()
IndexError: pop from an empty deque
Traceback (most recent call last):
  File "/Users/ikedaleo/work/geekie/geekie-custom-study-data/.venv/lib/python3.13/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
    ~~~~~~~~~~~~~^^
  File "/Users/ikedaleo/work/geekie/geekie-custom-study-data/.venv/lib/python3.13/site-packages/pika/adapters/utils/io_services_utils.py", line 822, in _produce
    chunk = self._tx_buffers.popleft()
IndexError: pop from an empty deque
ERROR    pika.channel:channel.py:1440 Unexpected frame: <METHOD(['channel_number=1', 'frame_type=1', "method=<Basic.CancelOk(['consumer_tag=ctag1.3a5382e06261499287c81fa4cc2fa945'])>"])>
ERROR    pika.adapters.base_connection:base_connection.py:428 connection_lost: StreamLostError: ("Stream connection lost: IndexError('pop from an empty deque')",)
ERROR    pika.adapters.blocking_connection:blocking_connection.py:521 Unexpected connection close detected: StreamLostError: ("Stream connection lost: IndexError('pop from an empty deque')",)
ERROR    pika.adapters.blocking_connection:blocking_connection.py:521 Unexpected connection close detected: StreamLostError: ("Stream connection lost: IndexError('pop from an empty deque')",)
ERROR    root:rabbitmq_consumer_adapter.py:71 Erro ao iniciar consumo com dados do adapter: ConnectionParameters(host=localhost, port=5672, user=mq_user, password=****, cluster_hosts=None)

(...)

================================================================================== short test summary info ==================================================================================
ERROR <test-case> - pika.exceptions.StreamLostError: Stream connection lost: IndexError('pop from an empty deque')
==================================================================== 1 passed, 1 error in 2.59s ====================================================================
```

Depois de muito pesquisar sobre e investigar o código, percebi que o problema estava na forma em que a lib tenta fazer o término das conexões manualmente.

A [lib `pika` não é thread-safe](https://pika.readthedocs.io/en/stable/faq.html#frequently-asked-questions), e recomenda-se que conexões não sejam compartilhadas entre diferentes threads. A lib faz isso da forma correta: a thread de cada consumidor tem uma conexão própria. Entretanto, para terminar a conexão, o que estava sendo feito era a *thread principal* tentar fechar um `pika.BlockingChannel` compartilhado com a thread que roda o consumer.

Após pesquisar um pouco e ler a documentação, vi que o ideal é que a própria thread encerre a conexão com o channel associado a ela.

# Mudanças

- Para encerrar a conexão do channel, segui o recomendado pela documentação da `pika`, de utilizar o método [`add_callback_threadsafe` da conexão](https://pika.readthedocs.io/en/stable/modules/adapters/blocking.html?highlight=add_callback_threadsafe#pika.adapters.blocking_connection.BlockingConnection.add_callback_threadsafe) para executar uma callback responsável por encerrar a conexão.
- Adicionei um teste automatizado verificando que o problema que tive não ocorre mais

# Plano de testes
Além de rodar os testes automatizado e verificar que estão passando, e também verificar que com as mudanças meu projeto deixou de ter problemas, um teste fácil de fazer é:
- Rodar o docker-compose deste repositório para subir a instância do RabbitMQ:
- Abrir um console do python e executar:

```python
from hijiki.manager.message_manager_builder import MessageManagerBuilder

host = "localhost"
port = "5672"
user = "user"
pw = "pwd"

b1 = (
MessageManagerBuilder()
.with_host(host)
.with_port(port)
.with_user(user)
.with_password(pw)
.build()
)

def print_incoming(data):
    print(f"Consumer received: {data}")

from hijiki.config.consumer_data import ConsumerData
cd1 = ConsumerData("shutdown_test_queue", "shutdown_test_topic", print_incoming)
b1.create_consumer(cd1)

cd2 = ConsumerData("shutdown_test_queue_2", "shutdown_test_topic_2", print_incoming)
b1.create_consumer(cd2)

cons1 = b1.consumers.get("shutdown_test_queue")
vars(cons1)

cons2 = b1.consumers.get("shutdown_test_queue_2")
vars(cons2)

b1.start_consuming()

print("==== After started consuming =====")

vars(cons1) 
vars(cons2)

b1.stop_consuming()

print("==== After stopped consuming =====")

vars(cons1)
vars(cons2)
```
- Antes das mudanças, uma exceção estoura ao tentar executar `b1.stop_consuming()`:
```python
>>> b1.stop_consuming()
>>> 
>>> print("==== After stopped consuming =====")
ERROR:pika.adapters.utils.io_services_utils:_AsyncBaseTransport._produce() failed, aborting connection: error=IndexError('pop from an empty deque'); sock=<socket.socket fd=13, family=AddressFamily.AF_INET6, type=SocketKind.SOCK_STREAM, proto=6, laddr=('::1', 56350, 0, 0), raddr=('::1', 5672, 0, 0)>; Caller's stack:
Traceback (most recent call last):
  File "/Users/ikedaleo/.pyenv/versions/hijiki/lib/python3.9/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
  File "/Users/ikedaleo/.pyenv/versions/hijiki/lib/python3.9/site-packages/pika/adapters/utils/io_services_utils.py", line 822, in _produce
    chunk = self._tx_buffers.popleft()
IndexError: pop from an empty deque
Traceback (most recent call last):
  File "/Users/ikedaleo/.pyenv/versions/hijiki/lib/python3.9/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
  File "/Users/ikedaleo/.pyenv/versions/hijiki/lib/python3.9/site-packages/pika/adapters/utils/io_services_utils.py", line 822, in _produce
    chunk = self._tx_buffers.popleft()
IndexError: pop from an empty deque
==== After stopped consuming =====
ERROR:pika.adapters.base_connection:connection_lost: StreamLostError: ("Stream connection lost: IndexError('pop from an empty deque')",)
ERROR:pika.adapters.blocking_connection:Unexpected connection close detected: StreamLostError: ("Stream connection lost: IndexError('pop from an empty deque')",)
ERROR:root:Erro ao iniciar consumo com dados do adapter: ConnectionParameters(host=localhost, port=5672, user=user, password=****, cluster_hosts=None)
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/Users/ikedaleo/.pyenv/versions/3.9.16/lib/python3.9/threading.py", line 980, in _bootstrap_inner
```

- Após as mudanças, nenhuma exceção ocorre e é possível ver pelo print das variáveis dos consumers que a conexão foi encerrada adequadamente:
```python
==== After started consuming =====
>>> 
>>> vars(cons1) 
{'rabbit_connection': <BlockingConnection impl=<SelectConnection OPEN transport=<pika.adapters.utils.io_services_utils._AsyncPlaintextTransport object at 0x10eb30040> params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>, 'connection': <hijiki.connection.rabbitmq_connection.RabbitMQConnection object at 0x10d7eafa0>, 'connection_data': <hijiki.connection.rabbitmq_connection.ConnectionParameters object at 0x10d897760>, 'channel': <BlockingChannel impl=<Channel number=1 OPEN conn=<SelectConnection OPEN transport=<pika.adapters.utils.io_services_utils._AsyncPlaintextTransport object at 0x10eb30040> params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>>, 'queue': 'shutdown_test_queue', 'topic': 'shutdown_test_topic', 'handler': <function print_incoming at 0x10d375040>, 'auto_ack': False, 'routing_key': '*', '_consumer_thread': <Thread(Thread-2, started daemon 13082107904)>, 'create_dlq': True}
>>> vars(cons2)
{'rabbit_connection': <BlockingConnection impl=<SelectConnection OPEN transport=<pika.adapters.utils.io_services_utils._AsyncPlaintextTransport object at 0x10eb993d0> params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>, 'connection': <hijiki.connection.rabbitmq_connection.RabbitMQConnection object at 0x10eb4f7c0>, 'connection_data': <hijiki.connection.rabbitmq_connection.ConnectionParameters object at 0x10d897760>, 'channel': <BlockingChannel impl=<Channel number=1 OPEN conn=<SelectConnection OPEN transport=<pika.adapters.utils.io_services_utils._AsyncPlaintextTransport object at 0x10eb993d0> params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>>, 'queue': 'shutdown_test_queue_2', 'topic': 'shutdown_test_topic_2', 'handler': <function print_incoming at 0x10d375040>, 'auto_ack': False, 'routing_key': '*', '_consumer_thread': <Thread(Thread-4, started daemon 13098897408)>, 'create_dlq': True}
>>> 
>>> b1.stop_consuming()
>>> 
>>> print("==== After stopped consuming =====")
==== After stopped consuming =====
>>> 
>>> vars(cons1)
{'rabbit_connection': <BlockingConnection impl=<SelectConnection CLOSED transport=None params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>, 'connection': <hijiki.connection.rabbitmq_connection.RabbitMQConnection object at 0x10d7eafa0>, 'connection_data': <hijiki.connection.rabbitmq_connection.ConnectionParameters object at 0x10d897760>, 'channel': <BlockingChannel impl=<Channel number=1 CLOSED conn=<SelectConnection CLOSED transport=None params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>>, 'queue': 'shutdown_test_queue', 'topic': 'shutdown_test_topic', 'handler': <function print_incoming at 0x10d375040>, 'auto_ack': False, 'routing_key': '*', '_consumer_thread': <Thread(Thread-2, stopped daemon 13082107904)>, 'create_dlq': True}
>>> vars(cons2)
{'rabbit_connection': <BlockingConnection impl=<SelectConnection CLOSED transport=None params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>, 'connection': <hijiki.connection.rabbitmq_connection.RabbitMQConnection object at 0x10eb4f7c0>, 'connection_data': <hijiki.connection.rabbitmq_connection.ConnectionParameters object at 0x10d897760>, 'channel': <BlockingChannel impl=<Channel number=1 CLOSED conn=<SelectConnection CLOSED transport=None params=<URLParameters host=localhost port=5672 virtual_host=/ ssl=False>>>>, 'queue': 'shutdown_test_queue_2', 'topic': 'shutdown_test_topic_2', 'handler': <function print_incoming at 0x10d375040>, 'auto_ack': False, 'routing_key': '*', '_consumer_thread': <Thread(Thread-4, stopped daemon 13098897408)>, 'create_dlq': True}
```