### PR TITLE
fix: Corrige falha nos testes causada pelos fixes recentes

### DIFF
--- a/hijiki/adapters/rabbitmq_adapter.py
+++ b/hijiki/adapters/rabbitmq_adapter.py
@@ -19,13 +19,15 @@ class RabbitMQAdapter:
     def stop_consuming(self):
         if self.channel.is_open:
             self.channel.close()
+        if self.rabbit_connection and self.rabbit_connection.is_open:
+            self.rabbit_connection.close()
 
 
     def ping(self):
         """Verifica se a conexão está ativa."""
         result = False
         try:
-            if self.rabbit_connection and self.rabbit_connection.is_open():
+            if self.rabbit_connection and self.rabbit_connection.is_open:
                 self.rabbit_connection.process_data_events()
                 result = True
         except Exception as e:

--- a/hijiki/adapters/rabbitmq_consumer_adapter.py
+++ b/hijiki/adapters/rabbitmq_consumer_adapter.py
@@ -77,6 +77,17 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
         self._consumer_thread = threading.Thread(target=self._consume, daemon=True)
         self._consumer_thread.start()
         logging.info(f"Thread de consumo iniciada para a fila: {self.queue}")
+    
 
+    def stop_consuming(self):
+        def _stop_consuming():
+            if self.get_channel().is_open:
+                logging.info(f"Parando consumo da fila: {self.queue}")
+                self.get_channel().stop_consuming()
 
+        if self._consumer_thread and self._consumer_thread.is_alive():
+            if self.rabbit_connection and self.rabbit_connection.is_open:
+                self.rabbit_connection.add_callback_threadsafe(_stop_consuming)
 
+            self._consumer_thread.join()
+            super().stop_consuming()

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -10,6 +10,42 @@ result_data_list_dlq_for_specific_routing_key = []
 
 class Runner():
     def __init__(self):
+        @consumer_handler(queue_name="teste1")
+        def internal_consumer(data):
+            print(f"consumiu o valor:{data}")
+            result_data_list.append(data)
+            result_event_list.append('received event')
+
+        @consumer_handler(queue_name="teste1_dlq", create_dlq=False)
+        def internal_consumer_dlq(data):
+            print(f"consumiu o valor:{data}")
+            result_event_list_dlq.append('received event')
+
+        @consumer_handler(queue_name="fila_erro", topic="erro_event")
+        def internal_consumer_erro(data):
+            print(f"consumiu o valor:{data}")
+            result_event_list.append('received event')
+            raise Exception("falhou")
+
+        @consumer_handler(queue_name="fila_erro_dlq", topic="fila_erro_dlq_event", create_dlq=False)
+        def internal_consumer_erro_dlq(data):
+            print(f"consumiu o valor:{data}")
+            result_event_list_dlq.append('received event')
+
+        @consumer_handler(queue_name="without_dlq", topic="without_dlq", create_dlq=False)
+        def internal_consumer_extra(data):
+            print(f"consumiu o valor:{data}")
+            result_data_list.append(data)
+            result_event_list.append('received event')
+            raise Exception("falhou")
+
+        @consumer_handler(queue_name="teste_with_specific_routing_key", topic='teste1_event',
+                        routing_key="specific_routing_key")
+        def internal_consumer(data):
+            print(f"consumiu o valor:{data}")
+            result_data_list.append(data)
+            result_data_list_dlq_for_specific_routing_key.append('received event')
+
         self.gr = (MessageManagerBuilder.get_instance()\
             .with_user("user")\
             .with_password("pwd")\
@@ -17,43 +53,6 @@ class Runner():
             .with_port(5672)
             .build())
         self.threads = []
-
-
-    @consumer_handler(queue_name="teste1")
-    def internal_consumer(data):
-        print(f"consumiu o valor:{data}")
-        result_data_list.append(data)
-        result_event_list.append('received event')
-
-    @consumer_handler(queue_name="teste1_dlq", create_dlq=False)
-    def internal_consumer_dlq(data):
-        print(f"consumiu o valor:{data}")
-        result_event_list_dlq.append('received event')
-
-    @consumer_handler(queue_name="fila_erro", topic="erro_event")
-    def internal_consumer_erro(data):
-        print(f"consumiu o valor:{data}")
-        result_event_list.append('received event')
-        raise Exception("falhou")
-
-    @consumer_handler(queue_name="fila_erro_dlq", topic="fila_erro_dlq_event", create_dlq=False)
-    def internal_consumer_erro_dlq(data):
-        print(f"consumiu o valor:{data}")
-        result_event_list_dlq.append('received event')
-
-    @consumer_handler(queue_name="without_dlq", topic="without_dlq", create_dlq=False)
-    def internal_consumer_extra(data):
-        print(f"consumiu o valor:{data}")
-        result_data_list.append(data)
-        result_event_list.append('received event')
-        raise Exception("falhou")
-
-    @consumer_handler(queue_name="teste_with_specific_routing_key", topic='teste1_event',
-                      routing_key="specific_routing_key")
-    def internal_consumer(data):
-        print(f"consumiu o valor:{data}")
-        result_data_list.append(data)
-        result_data_list_dlq_for_specific_routing_key.append('received event')
 
 
     def run(self):

--- a/tests/test_mesage_manager.py
+++ b/tests/test_mesage_manager.py
@@ -1,6 +1,5 @@
 import time
 import unittest
-import pytest
 from unittest.mock import Mock
 
 from hijiki.adapters.rabbitmq_broker import RabbitMQBroker

--- a/tests/test_mesage_manager.py
+++ b/tests/test_mesage_manager.py
@@ -1,11 +1,17 @@
+import time
 import unittest
+import pytest
 from unittest.mock import Mock
 
+from hijiki.adapters.rabbitmq_broker import RabbitMQBroker
 from hijiki.config.consumer_data import ConsumerData
+from hijiki.connection.rabbitmq_connection import ConnectionParameters
+from hijiki.manager.message_manager_builder import MessageManagerBuilder
 from hijiki.ports.message_broker import MessageBroker
 from hijiki.manager.message_manager import MessageManager
 import json
 
+SECS_TO_AWAIT_BROKER = 2
 
 def _other_message_mapper(event_name: str, data: str):
     return {"other_key": data, "event_name": event_name}
@@ -44,3 +50,19 @@ class TestMessageManager(unittest.TestCase):
     def test_start_consuming(self):
         self.manager.start_consuming()
         self.broker_mock.start_consuming.assert_called()
+
+    def test_stop_consuming_rabbitmq_running_consumer(self):
+        connection_params = ConnectionParameters("localhost", 5672, "user", "pwd")
+        actual_broker = RabbitMQBroker(connection_params)
+        manager = MessageManager(actual_broker)
+
+        consumer_data = ConsumerData("test_queue", "test_topic", lambda x: x)
+        manager.create_consumer(consumer_data)
+
+        manager.start_consuming()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertTrue(manager.is_alive())
+
+        manager.stop_consuming()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertFalse(manager.is_alive())


### PR DESCRIPTION
# Contexto

Os PRs #27 e #28 foram recentemente mergeados na `main`, mas as mudanças incluídas neles estavam fazendo alguns testes quebrar. O #28 foi revertido, mas o #27 já está na `main`.

O objetivo deste PR é ajustar a causa da quebra dos testes.

Investigando, foi possível ver que a raíz do problema está no fato de que o setup do arquivo `tests/runner.py` estava sendo feito não em tempo de execução, mas em tempo de coleta dos testes. Por exemplo, mesmo ao rodar um teste que sequer importa o `Runner`, mas que usasse o `MessageManagerBuilder`, era possível ver os consumers criados por meio do decorator presentes.

O que parecia estar acontecendo é que, como o arquivo `tests/runner.py` está num diretório com o nome `tests`, ele é coletado e inicialmente importado ao tentar chamar o executador dos testes. Como as funções decoradas fazem parte do corpo do `runner.py`, isso tudo era executado a instância do `MessageManagerBuilder`, que é um singleton, já era criada a priori.

Com isso, qualquer teste que recriasse o `MessageManagerBuilder` (que é o que um dos testes novos faz) quebra o setup dos testes de consumers e publishers, já que as funções decoradas não são novamente invocadas em tempo de execução, e esses testes dependem desse setup.

# Mudanças

- Revert do revert do #28, para trazer de volta as implementações feitas nele
- Ajustei o código do runner para que os consumers sejam criados sempre na inicialização da classe, isolando com isso o setup dessa classe. Assim, testes que dependam disso independem do que outros testes fazem em relação ao singleton do `MessageManagerBuilder`.

# Plano de testes
Rodei localmente os testes e passaram, e também verifiquei que a pipeline do GitHub foi bem sucedida