### PR TITLE
feature: permite a customização de parâmetros relacionados a conexão de publishers e consumers do RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # HIJIKI - Gerenciamento de Mensagens com RabbitMQ
+
 ## 📚 Sobre a biblioteca HIJIKI
 
 ### Versão 2
+
 Este documento descreve a biblioteca **HIJIKI** versão 2, que é uma evolução da versão 1, mantendo compatibilidade com o código existente. A versão 2 introduz melhorias significativas na estrutura e funcionalidade, mas não altera a API pública, garantindo que os usuários possam migrar facilmente sem necessidade de ajustes no código já implementado.
 para acesso a versão 1, consulte a documentação da [versão 1](README_v1.md) e para fontes a tag v1_latest
 
 HIJIKI é uma biblioteca Python de alto nível para gerenciamento de mensagens orientada a eventos, destinada a facilitar a criação, configuração e uso de consumidores e produtores de mensagens, principalmente utilizando **RabbitMQ** como broker. Seu objetivo é abstrair detalhes de implementação de fila e troca de mensagens, oferecendo uma interface intuitiva, flexível e adequada tanto para aplicações web quanto scripts standalone.
 
 **Principais Características:**
+
 - **Builder pattern** para configuração (`MessageManagerBuilder`), facilitando setup e customizações complexas.
 - **Gerenciamento simplificado de consumidores**: registre consumidores (filas, tópicos e handlers) rapidamente usando uma API intuitiva.
 - **Publicação fácil de mensagens**: uso direto de métodos para publicar em tópicos/fila, com suporte a mapeamento customizado de payloads.
@@ -16,19 +19,21 @@ HIJIKI é uma biblioteca Python de alto nível para gerenciamento de mensagens o
 - **Métodos utilitários** para manutenção do ciclo de vida do consumo, verificação de saúde (`is_alive`), troca dinâmica do broker, e registro em execução.
 
 **Principais Classes:**
+
 - `MessageManagerBuilder`: Classe principal para construir e configurar a stack.
 - `MessageManager`: Gerencia operações de envio e consumo de mensagens.
 - `ConsumerData`: Estrutura que associa uma fila, tópico e função handler.
 
 ---
 
-##  📦 Instalação
+## 📦 Instalação
+
 Clone este repositório e instale as dependências:
 
-``` shell
+```shell
 git clone https://github.com/asengardeon/hijiki.git
 cd hijiki
-pipenv  install 
+pipenv  install
 ```
 
 ## ⚙️ Detalhamento técnico dos métodos de uso
@@ -38,6 +43,7 @@ A seguir, um resumo técnico dos principais métodos empregados para utilizar a 
 ## 1. Criação e configuração do Manager
 
 A configuração é feita via padrão builder, permitindo customização das conexões e parâmetros:
+
 ```
 python
 manager = (
@@ -49,16 +55,28 @@ manager = (
     # outras opções, como troca do broker, etc.
     .build()
 )
+
+
 ```
+
 - **with_host(host: str)**: define o endereço do broker RabbitMQ.
 - **with_port(port: int)**: configura a porta de conexão.
 - **with_user(user: str), with_password(password: str)**: definem credenciais.
-- **build()**: instancia o manager, pronto para uso.
+- **with_cluster_hosts(cluster_hosts: str)**: define o endereço caso você precise se conectar a uma instância de múltiplos clusters.
+- **with_virtual_host(virtual_host: str)**: define a qual virtual host de uma instância a conexão é feita
+- **with_secure_protocol(use_secure_protocol: bool)**: define o uso ou não do protocolo `amqps` em vez do `amqp`, que é usado por padrão
+- **build()**: instancia e retorna o manager, pronto para uso.
 
 ## 2. Registro de consumidores
+
 ### Criando consumidor manualmente
-É preciso criar uma instância de `ConsumerData` associando uma fila, tópico e função de processamento.  
+
+É preciso criar uma instância de `ConsumerData` associando uma fila, tópico e função de processamento.
+
+Além dessas informações obrigatórias, o `ConsumerData` permite a customização de outros tipos de parâmetros. Por exemplo, caso você precise consumir filas e exchanges de uma instância que não esteja utilizando os parâmetros padrões usados por esta lib, como os tipos das filas e exchanges, é possível passar os tipos por meio dos parâmetros `queue_type` e `exchange_type` durante a instanciação da `ConsumerData`.
+
 O método **create_consumer** adiciona consumidores ao manager:
+
 ```
 python
 def process_message(msg):
@@ -67,12 +85,14 @@ def process_message(msg):
 consumer_data = ConsumerData("nome_da_fila", "nome_do_topico", process_message)
 manager.create_consumer(consumer_data)
 ```
+
 - O handler (função) será chamada a cada mensagem recebida nessa fila/tópico.
 
 ##Criando consumidor com decorator
 Você também pode usar o decorator `@consumer_handler` para registrar consumidores de forma mais simples:
 
-###  Modelo apenas determinando a fila
+### Modelo apenas determinando a fila
+
 ```
 @consumer_handler(queue_name="teste1")
     def internal_consumer(data):
@@ -80,14 +100,18 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
         result_data_list.append(data)
         result_event_list.append('received event')
 ```
-### Modelo determinando fila e que não cria fila DLQ automaticamente, aconselhado para consumidores dde filas DLQ 
+
+### Modelo determinando fila e que não cria fila DLQ automaticamente, aconselhado para consumidores dde filas DLQ
+
 ```
     @consumer_handler(queue_name="teste1_dlq", create_dlq=False)
     def internal_consumer_dlq(data):
         print(f"consumiu o valor:{data}")
         result_event_list_dlq.append('received event')
 ```
+
 ### Modelo determinando fila e tópico
+
 ```
     @consumer_handler(queue_name="fila_erro", topic="erro_event")
     def internal_consumer_erro(data):
@@ -95,7 +119,9 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
         result_event_list.append('received event')
         raise Exception("falhou")
 ```
+
 ### Modelos com uso de routing_key
+
 ```
     @consumer_handler(queue_name="teste_with_specific_routing_key", topic='teste1_event',
                       routing_key="specific_routing_key")
@@ -108,19 +134,38 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 ## 3. Início do consumo
 
 O método **start_consuming** inicia loops de consumo das filas para todos consumidores registrados:
+
 ```
 python
 manager.start_consuming()
 ```
+
 - No FastAPI, recomenda-se executar em thread separada para não bloquear o servidor.
 
 ## 4. Publicação de mensagens
 
 O método **publish** envia mensagens diretamente para a fila/ tópico definido:
+
 ```
 python
 manager.publish("nome_da_fila", "Conteúdo da mensagem")
 ```
+
+Por padrão, a publicação das mensagens é feita seguindo o formato `{ "value": <conteúdo da mensagem> }`, para filas do tipo `topic`, sem `routing_key` e parâmetro `reply_to`. Todos estes podem ser customizados se seu caso de uso não se adequar a isso:
+
+```python
+def custom_message_mapper(_topic: str, data: str):
+  return { "id": uuid(), "data": data }
+
+manager.publish(
+  "nome_da_fila",
+  "Conteúdo da mensagem",
+  message_mapper=custom_message_mapper
+  routing_key="my_routing_key",
+  reply_to="my_response_queue_name"
+)
+```
+
 - Mensagens podem ser publicadas a partir de endpoints FastAPI ou scripts Python, conforme exemplo.
 
 ---
@@ -165,6 +210,7 @@ manager.publish("nome_da_fila", "Conteúdo da mensagem")
    - Veja os consumidores recebendo mensagens no terminal onde o servidor está rodando (mensagens são exibidas via print).
 
 #### **Observações**
+
 - O consumidor é registrado e inicializado automaticamente ao subir o FastAPI.
 - O consumo roda em uma thread em paralelo ao servidor web.
 
@@ -177,6 +223,7 @@ manager.publish("nome_da_fila", "Conteúdo da mensagem")
 1. **Suba o RabbitMQ** em sua máquina local (`localhost:5672`).
 
 2. **Execute o script**:
+
    ```sh
    python examples/pure_python_example.py
    ```
@@ -186,6 +233,7 @@ manager.publish("nome_da_fila", "Conteúdo da mensagem")
    - O consumidor imprime no console todas as mensagens recebidas.
 
 #### **Observações**
+
 - Use `Ctrl+C` para interromper o consumo.
 
 ---

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ A seguir, um resumo técnico dos principais métodos empregados para utilizar a 
 
 A configuração é feita via padrão builder, permitindo customização das conexões e parâmetros:
 
-```
-python
+```python
 manager = (
     MessageManagerBuilder()
     .with_host("localhost")
@@ -55,8 +54,6 @@ manager = (
     # outras opções, como troca do broker, etc.
     .build()
 )
-
-
 ```
 
 - **with_host(host: str)**: define o endereço do broker RabbitMQ.
@@ -77,8 +74,7 @@ Além dessas informações obrigatórias, o `ConsumerData` permite a customizaç
 
 O método **create_consumer** adiciona consumidores ao manager:
 
-```
-python
+```python
 def process_message(msg):
     print(f"Mensagem recebida: {msg}")
 
@@ -93,7 +89,7 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 
 ### Modelo apenas determinando a fila
 
-```
+```python
 @consumer_handler(queue_name="teste1")
     def internal_consumer(data):
         print(f"consumiu o valor:{data}")
@@ -103,7 +99,7 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 
 ### Modelo determinando fila e que não cria fila DLQ automaticamente, aconselhado para consumidores dde filas DLQ
 
-```
+```python
     @consumer_handler(queue_name="teste1_dlq", create_dlq=False)
     def internal_consumer_dlq(data):
         print(f"consumiu o valor:{data}")
@@ -112,7 +108,7 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 
 ### Modelo determinando fila e tópico
 
-```
+```python
     @consumer_handler(queue_name="fila_erro", topic="erro_event")
     def internal_consumer_erro(data):
         print(f"consumiu o valor:{data}")
@@ -122,7 +118,7 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 
 ### Modelos com uso de routing_key
 
-```
+```python
     @consumer_handler(queue_name="teste_with_specific_routing_key", topic='teste1_event',
                       routing_key="specific_routing_key")
     def internal_consumer(data):
@@ -135,8 +131,7 @@ Você também pode usar o decorator `@consumer_handler` para registrar consumido
 
 O método **start_consuming** inicia loops de consumo das filas para todos consumidores registrados:
 
-```
-python
+```python
 manager.start_consuming()
 ```
 
@@ -146,8 +141,7 @@ manager.start_consuming()
 
 O método **publish** envia mensagens diretamente para a fila/ tópico definido:
 
-```
-python
+```python
 manager.publish("nome_da_fila", "Conteúdo da mensagem")
 ```
 

--- a/hijiki/adapters/rabbitmq_broker.py
+++ b/hijiki/adapters/rabbitmq_broker.py
@@ -1,5 +1,6 @@
 
 import logging
+from typing import Optional
 
 from hijiki.config.consumer_data import ConsumerData
 from hijiki.ports.message_broker import MessageBroker
@@ -13,9 +14,10 @@ class RabbitMQBroker(MessageBroker):
         self.connection_params = connection_params
         self.consumers = {}
 
-    def publish(self, topic: str, message: str, routing_key: str = 'x', message_mapper=None):
+    def publish(self, topic: str, message: str, routing_key: str = 'x', exchange_type: Optional[str] = "topic",
+                reply_to: Optional[str] = None):
         publisher = PublisherRabbitMQAdapter(self.connection_params)
-        publisher.publish(topic, message, routing_key)
+        publisher.publish(topic, message, routing_key, exchange_type, reply_to)
 
     def create_consumer(self, consumer_data: ConsumerData):
         if consumer_data.handler:

--- a/hijiki/adapters/rabbitmq_consumer_adapter.py
+++ b/hijiki/adapters/rabbitmq_consumer_adapter.py
@@ -25,14 +25,19 @@ class ConsumerRabbitMQAdapter(RabbitMQAdapter):
 
     def create_exchange_and_queue(self):
         channel = self.get_channel()
-        default_queue_args = { "x-delivery-limit": 10 }
         default_queue_type = "quorum"
+        default_queue_args_by_type = {
+            "quorum": { "x-delivery-limit": 10 },
+            "classic": {},
+            "stream": {},
+        }
+        queue_type = self.queue_type or default_queue_type
         queue_args = (
             self.custom_queue_args
             if self.custom_queue_args is not None
-            else default_queue_args
+            else default_queue_args_by_type.get(queue_type, {})
         )
-        queue_args["x-queue-type"] = self.queue_type or default_queue_type
+        queue_args["x-queue-type"] = queue_type
 
         default_exchange_type = "topic"
         exchange_type = self.exchange_type or default_exchange_type

--- a/hijiki/adapters/rabbitmq_publisher_adapter.py
+++ b/hijiki/adapters/rabbitmq_publisher_adapter.py
@@ -17,14 +17,10 @@ class PublisherRabbitMQAdapter(RabbitMQAdapter):
         channel = self.get_channel()
         channel.exchange_declare(exchange=topic, exchange_type=exchange_type, durable=True)
 
-        properties_kwargs = { "delivery_mode": 2 }
-        if reply_to:
-            properties_kwargs["reply_to"] = reply_to
-
         channel.basic_publish(
             exchange=topic,
             routing_key=routing_key,
             body=message,
-            properties=pika.BasicProperties(**properties_kwargs)
+            properties=pika.BasicProperties(delivery_mode=2, reply_to=reply_to)
         )
         logging.info(f"Mensagem enviada para o tópico {topic}: {message}")

--- a/hijiki/adapters/rabbitmq_publisher_adapter.py
+++ b/hijiki/adapters/rabbitmq_publisher_adapter.py
@@ -12,13 +12,19 @@ class PublisherRabbitMQAdapter(RabbitMQAdapter):
         super().__init__(connection_data)
         self.connect()
 
-    def publish(self, topic: str, message: str, routing_key: Optional[str] = "x"):
+    def publish(self, topic: str, message: str, routing_key: Optional[str] = "x",
+                exchange_type: Optional[str] = "topic", reply_to: Optional[str] = None):
         channel = self.get_channel()
-        channel.exchange_declare(exchange=topic, exchange_type='topic', durable=True)
+        channel.exchange_declare(exchange=topic, exchange_type=exchange_type, durable=True)
+
+        properties_kwargs = { "delivery_mode": 2 }
+        if reply_to:
+            properties_kwargs["reply_to"] = reply_to
+
         channel.basic_publish(
             exchange=topic,
             routing_key=routing_key,
             body=message,
-            properties=pika.BasicProperties(delivery_mode=2)
+            properties=pika.BasicProperties(**properties_kwargs)
         )
         logging.info(f"Mensagem enviada para o tópico {topic}: {message}")

--- a/hijiki/config/consumer_data.py
+++ b/hijiki/config/consumer_data.py
@@ -2,7 +2,9 @@ from typing import Callable, Optional
 
 class ConsumerData:
     def __init__(self, queue: str, topic: str, handler: Callable, dlq_handler: Optional[Callable] = None,
-                 routing_key: Optional[str] = "*", auto_ack: Optional[bool] = False, create_dlq:bool = True):
+                 routing_key: Optional[str] = "*", auto_ack: Optional[bool] = False, create_dlq:bool = True,
+                 queue_type: Optional[str] = None, exchange_type: Optional[str] = None, dlq_name: Optional[str] = None,
+                 dlx_name: Optional[str] = None, custom_queue_args: Optional[dict] = None):
         self.queue = queue
         self.topic = topic
         self.handler = handler
@@ -10,3 +12,8 @@ class ConsumerData:
         self.auto_ack = auto_ack
         self.routing_key = routing_key
         self.create_dlq = create_dlq
+        self.queue_type = queue_type
+        self.exchange_type = exchange_type
+        self.dlq_name = dlq_name
+        self.dlx_name = dlx_name
+        self.custom_queue_args = custom_queue_args

--- a/hijiki/connection/rabbitmq_connection.py
+++ b/hijiki/connection/rabbitmq_connection.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import quote
 
 import pika
 from typing import Optional
@@ -26,7 +27,7 @@ class RabbitMQConnection:
         """Inicializa a conexão com o RabbitMQ usando um objeto ConnectionParameters."""
         self.host = connection_params.host if connection_params and connection_params.host else BrokerConfig.get_host()
         self.port = connection_params.port if connection_params and connection_params.port else BrokerConfig.get_port()
-        self.virtual_host = f"/{connection_params.virtual_host}" if connection_params and connection_params.virtual_host else ""
+        self.virtual_host = f"/{quote(connection_params.virtual_host, safe='')}" if connection_params and connection_params.virtual_host else ""
         self.user = connection_params.user if connection_params and connection_params.user else BrokerConfig.get_user()
         self.password = connection_params.password if connection_params and connection_params.password else BrokerConfig.get_password()
         self.cluster_hosts = connection_params.cluster_hosts if connection_params and connection_params.cluster_hosts else BrokerConfig.get_cluster_hosts()
@@ -51,11 +52,8 @@ class RabbitMQConnection:
         protocol = "amqps" if self.use_secure_protocol else "amqp"
         if self.cluster_hosts:
             cluster = self.cluster_hosts.split(",")
-            urls = [f"{protocol}://{self.user}:{self.password}@{host}{url_connectio_params}" for host in cluster]
-            final_url = ";".join(urls)
-            if self.virtual_host:
-                final_url += f"{self.virtual_host}"
-            return final_url
+            urls = [f"{protocol}://{self.user}:{self.password}@{host}{self.virtual_host}{url_connectio_params}" for host in cluster]
+            return ";".join(urls)
         else:
             return f"{protocol}://{self.user}:{self.password}@{self.host}:{self.port}{self.virtual_host}{url_connectio_params}"
 

--- a/hijiki/connection/rabbitmq_connection.py
+++ b/hijiki/connection/rabbitmq_connection.py
@@ -31,6 +31,7 @@ class RabbitMQConnection:
         self.password = connection_params.password if connection_params and connection_params.password else BrokerConfig.get_password()
         self.cluster_hosts = connection_params.cluster_hosts if connection_params and connection_params.cluster_hosts else BrokerConfig.get_cluster_hosts()
         self.extra_connection_params = connection_params.extra_connection_params if connection_params and connection_params.extra_connection_params else {}
+        self.use_secure_protocol = connection_params.use_secure_protocol if connection_params and connection_params.use_secure_protocol else False
         self.connection = None
 
     def __validate_host(self):

--- a/hijiki/connection/rabbitmq_connection.py
+++ b/hijiki/connection/rabbitmq_connection.py
@@ -7,22 +7,26 @@ from hijiki.config.broker_config import BrokerConfig
 
 
 class ConnectionParameters:
-    def __init__(self, host: str = None, port: int = None, user: str = None, password: str = None, cluster_hosts: str="", extra_connection_params: Optional[dict] = None):
+    def __init__(self, host: str = None, port: int = None, virtual_host: str = None, user: str = None,
+                 password: str = None, cluster_hosts: str="", use_secure_protocol: bool = False, extra_connection_params: Optional[dict] = None):
         self.host = host
         self.port = port
+        self.virtual_host = virtual_host
         self.user = user
         self.password = password
         self.cluster_hosts = cluster_hosts
+        self.use_secure_protocol = use_secure_protocol
         self.extra_connection_params = extra_connection_params or {}
 
     def __str__(self):
-        return f"ConnectionParameters(host={self.host}, port={self.port}, user={self.user}, password=****, cluster_hosts={self.cluster_hosts})"
+        return f"ConnectionParameters(host={self.host}, port={self.port}, virtual_host={self.virtual_host}, user={self.user}, password=****, cluster_hosts={self.cluster_hosts})"
 
 class RabbitMQConnection:
     def __init__(self, connection_params: ConnectionParameters = None):
         """Inicializa a conexão com o RabbitMQ usando um objeto ConnectionParameters."""
         self.host = connection_params.host if connection_params and connection_params.host else BrokerConfig.get_host()
         self.port = connection_params.port if connection_params and connection_params.port else BrokerConfig.get_port()
+        self.virtual_host = f"/{connection_params.virtual_host}" if connection_params and connection_params.virtual_host else ""
         self.user = connection_params.user if connection_params and connection_params.user else BrokerConfig.get_user()
         self.password = connection_params.password if connection_params and connection_params.password else BrokerConfig.get_password()
         self.cluster_hosts = connection_params.cluster_hosts if connection_params and connection_params.cluster_hosts else BrokerConfig.get_cluster_hosts()
@@ -43,12 +47,16 @@ class RabbitMQConnection:
         self.__validate_host()
         """Gera a URL de conexão para o broker."""
         url_connectio_params = self._get_connecttion_url_params()
+        protocol = "amqps" if self.use_secure_protocol else "amqp"
         if self.cluster_hosts:
-            cluster = self.cluster_hosts.split(',')
-            urls = [f'amqp://{self.user}:{self.password}@{host}{url_connectio_params}' for host in cluster]
-            return ';'.join(urls)
+            cluster = self.cluster_hosts.split(",")
+            urls = [f"{protocol}://{self.user}:{self.password}@{host}{url_connectio_params}" for host in cluster]
+            final_url = ";".join(urls)
+            if self.virtual_host:
+                final_url += f"{self.virtual_host}"
+            return final_url
         else:
-            return f'amqp://{self.user}:{self.password}@{self.host}:{self.port}{url_connectio_params}'
+            return f"{protocol}://{self.user}:{self.password}@{self.host}:{self.port}{self.virtual_host}{url_connectio_params}"
 
     def connect(self):
         broker_url = self.get_broker_url()

--- a/hijiki/decorators/decorator.py
+++ b/hijiki/decorators/decorator.py
@@ -5,9 +5,9 @@ from hijiki.manager.message_manager_builder import MessageManagerBuilder
 
 
 def consumer_handler(queue_name: str, topic: Optional[str] = None, routing_key: Optional[str] = None,
-                     create_dlq=True) -> Callable:
+                     create_dlq=True, exchange_type: Optional[str] = None) -> Callable:
     def decorator(func: Callable):
-        consumer_data = ConsumerData(queue=queue_name, topic=topic or f"{queue_name}_event", handler=func, routing_key=routing_key, create_dlq=create_dlq)
+        consumer_data = ConsumerData(queue=queue_name, topic=topic or f"{queue_name}_event", handler=func, routing_key=routing_key, create_dlq=create_dlq, exchange_type=exchange_type)
         manager_builder =  MessageManagerBuilder.get_instance()
         if manager_builder:
             manager_builder.add_possible_consumer(consumer_data)

--- a/hijiki/decorators/decorator.py
+++ b/hijiki/decorators/decorator.py
@@ -5,9 +5,19 @@ from hijiki.manager.message_manager_builder import MessageManagerBuilder
 
 
 def consumer_handler(queue_name: str, topic: Optional[str] = None, routing_key: Optional[str] = None,
-                     create_dlq=True, exchange_type: Optional[str] = None) -> Callable:
+                     create_dlq=True, exchange_type: Optional[str] = None, dlq_name: Optional[str] = None,
+                     dlx_name: Optional[str] = None) -> Callable:
     def decorator(func: Callable):
-        consumer_data = ConsumerData(queue=queue_name, topic=topic or f"{queue_name}_event", handler=func, routing_key=routing_key, create_dlq=create_dlq, exchange_type=exchange_type)
+        consumer_data = ConsumerData(
+            queue=queue_name,
+            topic=topic or f"{queue_name}_event",
+            handler=func,
+            routing_key=routing_key,
+            create_dlq=create_dlq,
+            exchange_type=exchange_type,
+            dlq_name=dlq_name,
+            dlx_name=dlx_name
+        )
         manager_builder =  MessageManagerBuilder.get_instance()
         if manager_builder:
             manager_builder.add_possible_consumer(consumer_data)

--- a/hijiki/decorators/decorator.py
+++ b/hijiki/decorators/decorator.py
@@ -5,8 +5,8 @@ from hijiki.manager.message_manager_builder import MessageManagerBuilder
 
 
 def consumer_handler(queue_name: str, topic: Optional[str] = None, routing_key: Optional[str] = None,
-                     create_dlq=True, exchange_type: Optional[str] = None, dlq_name: Optional[str] = None,
-                     dlx_name: Optional[str] = None) -> Callable:
+                     create_dlq=True, exchange_type: Optional[str] = None, queue_type: Optional[str] = None,
+                     dlq_name: Optional[str] = None, dlx_name: Optional[str] = None) -> Callable:
     def decorator(func: Callable):
         consumer_data = ConsumerData(
             queue=queue_name,
@@ -15,6 +15,7 @@ def consumer_handler(queue_name: str, topic: Optional[str] = None, routing_key: 
             routing_key=routing_key,
             create_dlq=create_dlq,
             exchange_type=exchange_type,
+            queue_type=queue_type,
             dlq_name=dlq_name,
             dlx_name=dlx_name
         )

--- a/hijiki/manager/message_manager.py
+++ b/hijiki/manager/message_manager.py
@@ -20,13 +20,13 @@ class MessageManager:
         self.possible_consumers = []
 
     def publish(self, topic: str, message: str, message_mapper: Optional[Callable[[str, str], dict]]=default_message_mapper,
-                        routing_key=default_routing_key):
+                routing_key=default_routing_key, exchange_type: Optional[str] = "topic", reply_to: Optional[str] = None):
         if message_mapper:
             payload = message_mapper(topic, message)
         else:
             payload = default_message_mapper(topic, message)
         new_message = json.dumps(payload)
-        self.broker.publish(topic, new_message, routing_key)
+        self.broker.publish(topic, new_message, routing_key, exchange_type, reply_to)
         logging.info(f"Mensagem publicada no tópico {topic}: {message}")
 
     def create_consumer(self, consumer_data: ConsumerData):

--- a/hijiki/manager/message_manager_builder.py
+++ b/hijiki/manager/message_manager_builder.py
@@ -22,12 +22,14 @@ class MessageManagerBuilder:
         broker_config = BrokerConfig()
         self.host = broker_config.get_host()
         self.port = broker_config.get_port()
+        self.virtual_host = None
         self.user = broker_config.get_user()
         self.password = broker_config.get_password()
         self.cluster_hosts = broker_config.get_cluster_hosts()
         self.consumers_data = []
         self.broker_type = BrokerType.RABBITMQ
         self.heartbeat_interval = 60 # 60 é o tempo, em segundos, padrão do RabbitMQ desde a versão 3.3.5
+        self.use_secure_protocol = False
         self.manager = None
         MessageManagerBuilder._instance = self
         self.possible_consumers = []  # Lista de consumidores via decorator que podem ser registrados posteriormente.
@@ -44,6 +46,10 @@ class MessageManagerBuilder:
 
     def with_port(self, port: int):
         self.port = port
+        return self
+
+    def with_virtual_host(self, virtual_host: str):
+        self.virtual_host = virtual_host
         return self
 
     def with_user(self, user: str):
@@ -70,6 +76,10 @@ class MessageManagerBuilder:
         self.heartbeat_interval = heartbeat_interval
         return self
 
+    def with_secure_protocol(self, use_secure_protocol: bool):
+        self.use_secure_protocol = use_secure_protocol
+        return self
+
     def add_possible_consumer(self, consumer_data: ConsumerData):
         self.possible_consumers.append(consumer_data)
 
@@ -77,7 +87,7 @@ class MessageManagerBuilder:
         extra_params = {
             'heartbeat': self.heartbeat_interval
         }
-        connection_params = ConnectionParameters(self.host, self.port, self.user, self.password, self.cluster_hosts, extra_connection_params=extra_params)
+        connection_params = ConnectionParameters(self.host, self.port, self.virtual_host, self.user, self.password, self.cluster_hosts, self.use_secure_protocol, extra_connection_params=extra_params)
         broker = RabbitMQBroker(connection_params) if self.broker_type == BrokerType.RABBITMQ else None
         if not broker:
             raise ValueError("BrokerType inválido ou não suportado.")

--- a/hijiki/ports/message_broker.py
+++ b/hijiki/ports/message_broker.py
@@ -1,10 +1,12 @@
+from typing import Optional
 from hijiki.config.consumer_data import ConsumerData
 
 from abc import ABC, abstractmethod
 
 class MessageBroker(ABC):
     @abstractmethod
-    def publish(self, topic: str, message: str, routing_key: str = 'x', message_mapper=None):
+    def publish(self, topic: str, message: str, routing_key: str = 'x', exchange_type: Optional[str] = "topic",
+                reply_to: Optional[str] = None):
         pass
 
     @abstractmethod

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -46,6 +46,13 @@ class Runner():
             result_data_list.append(data)
             result_data_list_dlq_for_specific_routing_key.append('received event')
 
+        @consumer_handler(queue_name="with_direct_exchange", topic='with_direct_exchange_event',
+                        routing_key="direct_routing_key", exchange_type="direct")
+        def internal_consumer(data):
+            print(f"consumiu o valor:{data}")
+            result_data_list.append(data)
+            result_event_list.append('received event')
+
         self.gr = (MessageManagerBuilder.get_instance()\
             .with_user("user")\
             .with_password("pwd")\
@@ -86,5 +93,5 @@ class Runner():
     def set_auto_ack(self, auto_ack: bool):
         self.gr.with_auto_ack(auto_ack)
 
-    def publish_message(self, event_name, message, routing_key="x", message_mapper: Optional[Callable[[str, str], dict]] = None):
-        self.gr.publish(event_name, message, routing_key=routing_key, message_mapper=message_mapper)
+    def publish_message(self, event_name, message, routing_key="x", message_mapper: Optional[Callable[[str, str], dict]] = None, exchange_type: Optional[str] = "topic"):
+        self.gr.publish(event_name, message, routing_key=routing_key, message_mapper=message_mapper, exchange_type=exchange_type)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -69,7 +69,9 @@ class Runner():
             .with_user("user")\
             .with_password("pwd")\
             .with_host("localhost")\
-            .with_port(5672)
+            .with_port(5672)\
+            .with_secure_protocol(False)\
+            .with_virtual_host("/")\
             .build())
         self.threads = []
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -47,7 +47,7 @@ class Runner():
             result_data_list_dlq_for_specific_routing_key.append('received event')
 
         @consumer_handler(queue_name="with_direct_exchange", topic='with_direct_exchange_event',
-                        routing_key="direct_routing_key", exchange_type="direct")
+                        routing_key="direct_routing_key", exchange_type="direct", queue_type="classic")
         def internal_consumer(data):
             print(f"consumiu o valor:{data}")
             result_data_list.append(data)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -53,6 +53,18 @@ class Runner():
             result_data_list.append(data)
             result_event_list.append('received event')
 
+        @consumer_handler(queue_name="with.custom.dl.names", topic='with.custom.dl.names.event',
+                         dlq_name="test.dlq", dlx_name="test.dlx")
+        def internal_consumer(data):
+            print(f"consumiu o valor:{data}")
+            result_event_list.append('received event')
+            raise Exception("falhou")
+
+        @consumer_handler(queue_name="test.dlq", topic="test.dlx", create_dlq=False)
+        def internal_consumer_erro(data):
+            print(f"consumiu o valor:{data}")
+            result_event_list_dlq.append('received event')
+
         self.gr = (MessageManagerBuilder.get_instance()\
             .with_user("user")\
             .with_password("pwd")\

--- a/tests/test_broker_data_server_exists.py
+++ b/tests/test_broker_data_server_exists.py
@@ -67,3 +67,39 @@ class TestRabbitMQConnection(unittest.TestCase):
         connection = RabbitMQConnection(connection_parameters)
         expected_url = 'amqp://builder_user:builder_password@builder_host:5674?heartbeat=37'
         self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_virtual_host(self):
+        os.environ.pop('BROKER_CLUSTER_SERVER')
+        connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host')
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqp://env_user:env_password@env_host:5673/builder_virtual_host'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_virtual_host_and_cluster(self):
+        os.environ.pop('BROKER_SERVER')
+        connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host', cluster_hosts='builder_host1,builder_host2')
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqp://env_user:env_password@builder_host1;amqp://env_user:env_password@builder_host2/builder_virtual_host'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_virtual_host_and_cluster_and_heartbeat(self):
+        os.environ.pop('BROKER_SERVER')
+        connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host', cluster_hosts='builder_host1,builder_host2',
+                                                     extra_connection_params={"heartbeat":37})
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqp://env_user:env_password@builder_host1?heartbeat=37;amqp://env_user:env_password@builder_host2?heartbeat=37/builder_virtual_host'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_secure_protocol(self):
+        os.environ.pop('BROKER_CLUSTER_SERVER')
+        connection_parameters = ConnectionParameters(use_secure_protocol=True)
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqps://env_user:env_password@env_host:5673'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_secure_protocol_and_cluster(self):
+        os.environ.pop('BROKER_SERVER')
+        connection_parameters = ConnectionParameters(use_secure_protocol=True, cluster_hosts='builder_host1,builder_host2')
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqps://env_user:env_password@builder_host1;amqps://env_user:env_password@builder_host2'
+        self.assertEqual(connection.get_broker_url(), expected_url)

--- a/tests/test_broker_data_server_exists.py
+++ b/tests/test_broker_data_server_exists.py
@@ -75,11 +75,25 @@ class TestRabbitMQConnection(unittest.TestCase):
         expected_url = 'amqp://env_user:env_password@env_host:5673/builder_virtual_host'
         self.assertEqual(connection.get_broker_url(), expected_url)
 
+    def test_get_broker_url_with_properly_uri_encoded_virtual_host(self):
+        os.environ.pop('BROKER_CLUSTER_SERVER')
+        connection_parameters = ConnectionParameters(virtual_host='/')
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqp://env_user:env_password@env_host:5673/%2F'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
+    def test_get_broker_url_with_virtual_host_and_heartbeat(self):
+        os.environ.pop('BROKER_CLUSTER_SERVER')
+        connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host', extra_connection_params={"heartbeat":37})
+        connection = RabbitMQConnection(connection_parameters)
+        expected_url = 'amqp://env_user:env_password@env_host:5673/builder_virtual_host?heartbeat=37'
+        self.assertEqual(connection.get_broker_url(), expected_url)
+
     def test_get_broker_url_with_virtual_host_and_cluster(self):
         os.environ.pop('BROKER_SERVER')
         connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host', cluster_hosts='builder_host1,builder_host2')
         connection = RabbitMQConnection(connection_parameters)
-        expected_url = 'amqp://env_user:env_password@builder_host1;amqp://env_user:env_password@builder_host2/builder_virtual_host'
+        expected_url = 'amqp://env_user:env_password@builder_host1/builder_virtual_host;amqp://env_user:env_password@builder_host2/builder_virtual_host'
         self.assertEqual(connection.get_broker_url(), expected_url)
 
     def test_get_broker_url_with_virtual_host_and_cluster_and_heartbeat(self):
@@ -87,7 +101,7 @@ class TestRabbitMQConnection(unittest.TestCase):
         connection_parameters = ConnectionParameters(virtual_host='builder_virtual_host', cluster_hosts='builder_host1,builder_host2',
                                                      extra_connection_params={"heartbeat":37})
         connection = RabbitMQConnection(connection_parameters)
-        expected_url = 'amqp://env_user:env_password@builder_host1?heartbeat=37;amqp://env_user:env_password@builder_host2?heartbeat=37/builder_virtual_host'
+        expected_url = 'amqp://env_user:env_password@builder_host1/builder_virtual_host?heartbeat=37;amqp://env_user:env_password@builder_host2/builder_virtual_host?heartbeat=37'
         self.assertEqual(connection.get_broker_url(), expected_url)
 
     def test_get_broker_url_with_secure_protocol(self):

--- a/tests/test_consumer_data.py
+++ b/tests/test_consumer_data.py
@@ -24,3 +24,15 @@ class TestConsumerData(unittest.TestCase):
         self.assertEqual(consumer_data.topic, "test_topic")
         self.assertEqual(consumer_data.routing_key, "specific_routing_key")
         self.assertTrue(consumer_data.create_dlq)
+
+    def test_consumer_data_with_custom_queue_related_parameters(self):
+        handler_mock = Mock()
+        consumer_data = ConsumerData("test.queue", "test.exch", handler_mock, queue_type="classic",
+                                     exchange_type="direct", dlq_name="test.dlq", dlx_name="test.dlx")
+
+        self.assertEqual(consumer_data.queue, "test.queue")
+        self.assertEqual(consumer_data.topic, "test.exch")
+        self.assertEqual(consumer_data.queue_type, "classic")
+        self.assertEqual(consumer_data.exchange_type, "direct")
+        self.assertEqual(consumer_data.dlq_name, "test.dlq")
+        self.assertEqual(consumer_data.dlx_name, "test.dlx")

--- a/tests/test_mesage_manager.py
+++ b/tests/test_mesage_manager.py
@@ -25,7 +25,13 @@ class TestMessageManager(unittest.TestCase):
         topic = "test_topic"
         message = "test_message"
         self.manager.publish(topic, message)
-        self.broker_mock.publish.assert_called_with(topic, json.dumps({'value': 'test_message'}), 'x')
+        self.broker_mock.publish.assert_called_with(
+            topic,
+            json.dumps({'value': 'test_message'}),
+            'x',
+            'topic',
+            None
+        )
 
     def test_consume_a_message_with_other_mapper(self):
         event_name = 'teste1_event'
@@ -34,7 +40,9 @@ class TestMessageManager(unittest.TestCase):
         self.broker_mock.publish.assert_called_with(
             event_name,
             json.dumps(_other_message_mapper(event_name, message)),  # <- Aqui!
-            'x'
+            'x',
+            'topic',
+            None
         )
 
     def test_create_consumer(self):
@@ -51,7 +59,12 @@ class TestMessageManager(unittest.TestCase):
         self.broker_mock.start_consuming.assert_called()
 
     def test_stop_consuming_rabbitmq_running_consumer(self):
-        connection_params = ConnectionParameters("localhost", 5672, "user", "pwd")
+        connection_params = ConnectionParameters(
+            host="localhost",
+            port=5672,
+            user="user",
+            password="pwd"
+        )
         actual_broker = RabbitMQBroker(connection_params)
         manager = MessageManager(actual_broker)
 

--- a/tests/test_message_manager_builder.py
+++ b/tests/test_message_manager_builder.py
@@ -56,6 +56,20 @@ class TestMessageManagerBuilder(unittest.TestCase):
 
     @patch("hijiki.adapters.rabbitmq_adapter.RabbitMQAdapter", autospec=True)
     @patch("hijiki.connection.rabbitmq_connection.ConnectionParameters", spec=True)
+    def test_with_virtual_host_uses_virtual_host_in_connection_params(self, mock_connection_params, mock_adapter):
+        mock_adapter.return_value = Mock()
+        mock_connection_params.return_value = Mock()
+
+        builder = (
+            MessageManagerBuilder.get_instance()
+            .with_virtual_host("virtual_host")
+        )
+        manager = builder.build()
+
+        self.assertEqual(mock_connection_params.call_args[1]["virtual_host"], "virtual_host")
+
+    @patch("hijiki.adapters.rabbitmq_adapter.RabbitMQAdapter", autospec=True)
+    @patch("hijiki.connection.rabbitmq_connection.ConnectionParameters", spec=True)
     def test_recreate_builder_creates_new_instance_and_allows_new_manager_creation(self, mock_connection_params, mock_adapter):
         mock_adapter.return_value = Mock()
         mock_connection_params.return_value = Mock()

--- a/tests/test_message_manager_builder.py
+++ b/tests/test_message_manager_builder.py
@@ -55,18 +55,36 @@ class TestMessageManagerBuilder(unittest.TestCase):
         self.assertIn("queue2", manager.consumers)
 
     @patch("hijiki.adapters.rabbitmq_adapter.RabbitMQAdapter", autospec=True)
-    @patch("hijiki.connection.rabbitmq_connection.ConnectionParameters", spec=True)
+    @patch("hijiki.manager.message_manager_builder.ConnectionParameters", spec=True)
     def test_with_virtual_host_uses_virtual_host_in_connection_params(self, mock_connection_params, mock_adapter):
         mock_adapter.return_value = Mock()
         mock_connection_params.return_value = Mock()
 
         builder = (
             MessageManagerBuilder.get_instance()
-            .with_virtual_host("virtual_host")
+            .with_virtual_host("some_virtual_host")
         )
         manager = builder.build()
 
-        self.assertEqual(mock_connection_params.call_args[1]["virtual_host"], "virtual_host")
+        call_args = mock_connection_params.call_args[0]
+        virtual_host = call_args[2]
+        self.assertEqual(virtual_host, "some_virtual_host")
+
+    @patch("hijiki.adapters.rabbitmq_adapter.RabbitMQAdapter", autospec=True)
+    @patch("hijiki.manager.message_manager_builder.ConnectionParameters", spec=True)
+    def test_with_secure_protocol_uses_secure_protocol_in_connection_params(self, mock_connection_params, mock_adapter):
+        mock_adapter.return_value = Mock()
+        mock_connection_params.return_value = Mock()
+
+        builder = (
+            MessageManagerBuilder.get_instance()
+            .with_secure_protocol(True)
+        )
+        manager = builder.build()
+
+        call_args = mock_connection_params.call_args[0]
+        virtual_host = call_args[6]
+        self.assertEqual(virtual_host, True)
 
     @patch("hijiki.adapters.rabbitmq_adapter.RabbitMQAdapter", autospec=True)
     @patch("hijiki.connection.rabbitmq_connection.ConnectionParameters", spec=True)

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -24,8 +24,8 @@ class TestPublisherConsumer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.test_count != 9:
-            raise Exception(f"Expected 9 tests, but found {cls.test_count}. Please check the test cases.")
+        if cls.test_count != 10:
+            raise Exception(f"Expected 10 tests, but found {cls.test_count}. Please check the test cases.")
 
     def tearDown(self):
         self.runner.clear_results()
@@ -128,4 +128,17 @@ class TestPublisherConsumer(unittest.TestCase):
                                     routing_key='direct_routing_key', exchange_type='direct')
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.assertEqual(1, len(self.runner.get_results_data()))
+        TestPublisherConsumer.test_count += 1
+
+    def test_consume_a_message_with_custom_dead_letter_names(self):
+        self.runner.clear_results()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        for number in range(self.NUMBER_OF_QUEUED_MESSAGES):
+            self.runner.publish_message(
+                'with.custom.dl.names.event',
+                f'{{"value": "This is message number {number} that will be sent to dlq"}}'
+            )
+
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertEqual(self.NUMBER_OF_QUEUED_MESSAGES, len(self.runner.get_results_dlq()))
         TestPublisherConsumer.test_count += 1

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -121,7 +121,7 @@ class TestPublisherConsumer(unittest.TestCase):
         self.assertEqual(3, len(self.runner.get_results_data())) # são tres mensagens, pois a fila teste1_event recebe dois por causa do routing key coring "*"
         TestPublisherConsumer.test_count += 1
 
-    def test_consume_a_message_with_custom_exchange_type(self):
+    def test_consume_a_message_with_custom_exchange_and_queue_type(self):
         self.runner.clear_results()
         time.sleep(SECS_TO_AWAIT_BROKER)
         self.runner.publish_message('with_direct_exchange_event', '{"value": "This is the message"}',

--- a/tests/test_publisher_consumer_test.py
+++ b/tests/test_publisher_consumer_test.py
@@ -24,8 +24,8 @@ class TestPublisherConsumer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.test_count != 8:
-            raise Exception(f"Expected 8 tests, but found {cls.test_count}. Please check the test cases.")
+        if cls.test_count != 9:
+            raise Exception(f"Expected 9 tests, but found {cls.test_count}. Please check the test cases.")
 
     def tearDown(self):
         self.runner.clear_results()
@@ -119,4 +119,13 @@ class TestPublisherConsumer(unittest.TestCase):
         print(self.runner.get_result_for_specific_routing_key())
         self.assertEqual(1, len(self.runner.get_result_for_specific_routing_key()))
         self.assertEqual(3, len(self.runner.get_results_data())) # são tres mensagens, pois a fila teste1_event recebe dois por causa do routing key coring "*"
+        TestPublisherConsumer.test_count += 1
+
+    def test_consume_a_message_with_custom_exchange_type(self):
+        self.runner.clear_results()
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.runner.publish_message('with_direct_exchange_event', '{"value": "This is the message"}',
+                                    routing_key='direct_routing_key', exchange_type='direct')
+        time.sleep(SECS_TO_AWAIT_BROKER)
+        self.assertEqual(1, len(self.runner.get_results_data()))
         TestPublisherConsumer.test_count += 1


### PR DESCRIPTION
# Contexto

Estamos desenvolvendo um projeto que já usa esta lib e que precisa se comunicar com filas externas, com configurações já dadas. No estado atual, a lib não pode ser usada, e o objetivo é trazer as mudanças necessárias para permitir esse caso de uso específico.

Algumas das configurações dessa fila externa que entram em conflito com a forma que a lib está hoje incluem:
- Precisamos nos conectar a uma instância do RabbitMQ utilizando um `virtual host` e o protocolo `ampqs`
- Precisamos nos conectar a filas e exchanges com tipos e configurações diferentes das atuais forçadas pela lib (ex: hoje só são permitidas exchanges do tipo `topic` e filas do tipo `quorum`)
- Para a publicação de mensagens, precisaremos informar o parâmetro `reply_to` para que a aplicação responsável por consumir as mensagens saiba para qual fila retornar uma mensagem de resposta, e isto não é possível hoje
- As filas e exchanges dessa instância não seguem o padrão de nomenclatura da lib esperado na definição da DLQ e DLX (ex: utilizam um "dot case" em vez de snake case; `nome.da.fila.dlq` em vez de `nome_da_fila_dlq`)

A estratégia para incluir as mudanças foi um pouco na linha de fazer o mínimo necessário para que as coisas sejam utilizáveis, dado esses casos de uso necessáros.

Exemplo: precisaremos enviar mensagens com o parâmetro `reply_to` para esse serviço externo, que utiliza essa informação para saber em qual fila jogar a resposta. Entretanto, hoje não temos um caso de uso esperado similar ao que eles fazem -- não há necessidade de que um consumer criado pela `hijiki` consiga lidar com esse parâmetro. Por isso, tudo o que foi feito foi permitir a publicação de mensagens com o `reply_to`, mas nada foi feito em relação ao consumo.

# Mudanças
Para permitir o uso de virtual host e protocolo seguro `amqps`:
- Foram adicionadas opções de incluir esses parâmetros, opcionais, no `MessageManagerBuilder`
- O `RabbitMQConnection` foi alterado para considerar esses parâmetros durante a construção da URL e estabelecimento da conexão

Para permitir definir o tipo de exchange e o parâmetro `reply_to` na publicação:
- Os arquivos das classes `MessageManager` -> `MessageBroker`/`RabbitMQBroker` -> `RabbitMQPublisherAdapter` foram alterados para incluir isso

Para permitir a customização de parâmetros relacionados aos tipos e argumentos de filas/exchanges, e nomes da DLQ/DLX de consumidores:
- A classe `ConsumerData` foi alterada para permitir campos novos relacionados a isso
- A classe `ConsumerRabbitMQAdapter` foi alterada para utilizar essas informações durante a criação/conexão com as filas/exchanges/dlqs/dlx
- Foram adicionados testes automatizados cobrindo as mudanças introduzidas, com exceção da mudança relacionada ao parâmetro `reply_to`, já que hoje não há uma forma fácil de implementar um teste de integração que consiga verificar isso