### PR TITLE
Cria uma classe builder para encapsular menssagens ao rabbitmq

### DIFF
--- a/hijiki/builders/message_builder.py
+++ b/hijiki/builders/message_builder.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from typing import Dict, Any, Optional
+from hijiki.models.message_cover import MessageCover
+
+
+class MessageBuilder:
+    """
+    Classe para construir objetos MessageCover de forma fluente e segura.
+
+    Exemplo de uso:
+    builder = MessageBuilder()
+    capa = builder.with_version("v1").with_value({"id": 123}).build()
+    """
+    def __init__(self):
+        # Atributos internos para armazenar os dados da mensagem.
+        self._version: Optional[str] = None
+        self._value: Optional[Dict[str, Any]] = None
+        self._context: Optional[str] = None
+        self._extra_data: Optional[Dict[str, Any]] = None
+
+    def with_version(self, version: str) -> MessageBuilder:
+        self._version = version
+        return self
+
+    def with_value(self, value: Dict[str, Any]) -> MessageBuilder:
+        self._value = value
+        return self
+
+    def with_context(self, context: str) -> MessageBuilder:
+        self._context = context
+        return self
+
+    def with_extra_data(self, extra_data: Dict[str, Any]) -> MessageBuilder:
+        self._extra_data = extra_data
+        return self
+
+    def build(self) -> str:
+        if not self._version or not self._value:
+            raise ValueError("A versão e o valor da mensagem são obrigatórios e devem ser fornecidos.")
+
+        return MessageCover(
+            version=self._version,
+            value=self._value,
+            context=self._context,
+            extra_data=self._extra_data
+        ).model_dump_json(exclude_none=True)

--- a/hijiki/models/message_cover.py
+++ b/hijiki/models/message_cover.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Dict, Any, Optional
+from pydantic import BaseModel, Field
+
+
+class MessageCover(BaseModel):
+    version: str = Field(..., description="A versão da mensagem. Ex: 'v1'.")
+    value: Dict[str, Any] = Field(..., description="O objeto JSON com o payload real da mensagem.")
+    context: Optional[str] = Field(None, description="Um identificador de contexto opcional.")
+    extra_data: Optional[Dict[str, Any]] = Field(None, description="Um objeto com informações extras que não fazem parte do valor principal.")

--- a/tests/test_message_builder.py
+++ b/tests/test_message_builder.py
@@ -1,0 +1,70 @@
+import json
+import unittest
+from unittest.mock import patch
+from hijiki.builders.message_builder import MessageBuilder
+from hijiki.models.message_cover import MessageCover
+
+
+class TestMessageBuilder(unittest.TestCase):
+    def setUp(self):
+        self.payload = {"id": 1, "nome": "Teste"}
+
+    def test_message_builder_old_format(self):
+        def json_with_nulls(self, *args, **kwargs):
+            return json.dumps({
+                "version": self.version,
+                "value": self.value,
+                "context": self.context,
+                "extra_data": self.extra_data
+            })
+
+        with patch.object(MessageCover, "json", json_with_nulls):
+            mensagem_json = (
+                MessageBuilder()
+                .with_version("v1")
+                .with_value(self.payload)
+                .build()
+            )
+
+        data = json.loads(mensagem_json)
+        self.assertEqual(data["version"], "v1")
+        self.assertEqual(data["value"], self.payload)
+
+    def test_message_builder_new_format_excludes_none(self):
+        payload = {"id": 1, "nome": "Teste"}
+        mensagem_json = (
+            MessageBuilder()
+            .with_version("v1")
+            .with_value(payload)
+            .build()
+        )
+
+        data = json.loads(mensagem_json)
+        assert data["version"] == "v1"
+        assert data["value"] == payload
+        assert "context" not in data
+        assert "extra_data" not in data
+
+    def test_message_builder_with_all_fields(self):
+        payload = {"id": 42}
+        extra_data = {"debug": True}
+        mensagem_json = (
+            MessageBuilder()
+            .with_version("v2")
+            .with_value(payload)
+            .with_context("processamento")
+            .with_extra_data(extra_data)
+            .build()
+        )
+
+        data = json.loads(mensagem_json)
+        assert data["version"] == "v2"
+        assert data["value"] == payload
+        assert data["context"] == "processamento"
+        assert data["extra_data"] == extra_data
+
+    def test_message_builder_missing_required_fields(self):
+        builder = MessageBuilder()
+        with self.assertRaises(ValueError) as context:
+            builder.build()
+        self.assertIn("versão e o valor", str(context.exception))


### PR DESCRIPTION
## Contexto
Precisamos disponibilizar o suporte a uma capa de mensagem a lib. A capa tem por objetivo ser uma estrutura de metadados da mensagem, a fim de garantir compatibilidade de evolução da comunicação.

## Alterações
- Cria uma nova classe builder para encapsular as mensagens;
- Cria um model para definir o padrão das mensagens
- Adiciona testes para garantir o funcionamento dos dois formatos

## Evidências
- Script de teste para envio de mensage:

<img width="511" height="292" alt="image" src="https://github.com/user-attachments/assets/b7a0fa68-bfdb-462f-958a-8b0f0ca90e81" />

- Log da mensagem enviada para o rabbit:

<img width="624" height="40" alt="image" src="https://github.com/user-attachments/assets/772c5de6-29f3-4f31-8489-872d4e5ebc01" />

- Mensagem recebida no rabbit:

<img width="535" height="187" alt="image" src="https://github.com/user-attachments/assets/c2e5d7cc-04c8-48e8-9ae7-305b6201d9bb" />

## Test plan
- Instalar as dependências do projeto
- Enviar uma mensagem para o Rabbit utilizando a capa, exemplo de código:
```python
    message = (
        MessageBuilder()
        .with_version('v2')
        .with_value({"id": 1, "teste": "ok"})
        .build()
    )

    channel.basic_publish(
        exchange="",
        routing_key=QUEUE_NAME,
        body=message,
        properties=pika.BasicProperties(delivery_mode=2)
    )
``` 
- Verificar a mensagem no painel do Rabbit através do `http://localhost:15672/`