### PR TITLE
fix(je-1333): ajusta formato do message cover para utilizar classe pura

### DIFF
--- a/hijiki/builders/message_builder.py
+++ b/hijiki/builders/message_builder.py
@@ -43,4 +43,4 @@ class MessageBuilder:
             value=self._value,
             context=self._context,
             extra_data=self._extra_data
-        ).model_dump_json(exclude_none=True)
+        ).to_json()

--- a/hijiki/models/message_cover.py
+++ b/hijiki/models/message_cover.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
+import json
 from typing import Dict, Any, Optional
-from pydantic import BaseModel, Field
 
 
-class MessageCover(BaseModel):
-    version: str = Field(..., description="A versão da mensagem. Ex: 'v1'.")
-    value: Dict[str, Any] = Field(..., description="O objeto JSON com o payload real da mensagem.")
-    context: Optional[str] = Field(None, description="Um identificador de contexto opcional.")
-    extra_data: Optional[Dict[str, Any]] = Field(None, description="Um objeto com informações extras que não fazem parte do valor principal.")
+class MessageCover:
+    def __init__(
+        self,
+        version: str,
+        value: Dict[str, Any],
+        context: Optional[str] = None,
+        extra_data: Optional[Dict[str, Any]] = None
+    ) -> None:
+        self.version = version
+        self.value = value
+        self.context = context
+        self.extra_data = extra_data
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "version": self.version,
+            "value": self.value,
+        }
+        if self.context is not None:
+            data["context"] = self.context
+        if self.extra_data is not None:
+            data["extra_data"] = self.extra_data
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False)

--- a/tests/test_message_builder.py
+++ b/tests/test_message_builder.py
@@ -1,6 +1,5 @@
 import json
 import unittest
-from unittest.mock import patch
 from hijiki.builders.message_builder import MessageBuilder
 from hijiki.models.message_cover import MessageCover
 
@@ -9,41 +8,19 @@ class TestMessageBuilder(unittest.TestCase):
     def setUp(self):
         self.payload = {"id": 1, "nome": "Teste"}
 
-    def test_message_builder_old_format(self):
-        def json_with_nulls(self, *args, **kwargs):
-            return json.dumps({
-                "version": self.version,
-                "value": self.value,
-                "context": self.context,
-                "extra_data": self.extra_data
-            })
-
-        with patch.object(MessageCover, "json", json_with_nulls):
-            mensagem_json = (
-                MessageBuilder()
-                .with_version("v1")
-                .with_value(self.payload)
-                .build()
-            )
-
-        data = json.loads(mensagem_json)
-        self.assertEqual(data["version"], "v1")
-        self.assertEqual(data["value"], self.payload)
-
-    def test_message_builder_new_format_excludes_none(self):
-        payload = {"id": 1, "nome": "Teste"}
+    def test_message_builder_basic(self):
         mensagem_json = (
             MessageBuilder()
             .with_version("v1")
-            .with_value(payload)
+            .with_value(self.payload)
             .build()
         )
 
         data = json.loads(mensagem_json)
-        assert data["version"] == "v1"
-        assert data["value"] == payload
-        assert "context" not in data
-        assert "extra_data" not in data
+        self.assertEqual(data["version"], "v1")
+        self.assertEqual(data["value"], self.payload)
+        self.assertNotIn("context", data)
+        self.assertNotIn("extra_data", data)
 
     def test_message_builder_with_all_fields(self):
         payload = {"id": 42}
@@ -58,13 +35,26 @@ class TestMessageBuilder(unittest.TestCase):
         )
 
         data = json.loads(mensagem_json)
-        assert data["version"] == "v2"
-        assert data["value"] == payload
-        assert data["context"] == "processamento"
-        assert data["extra_data"] == extra_data
+        self.assertEqual(data["version"], "v2")
+        self.assertEqual(data["value"], payload)
+        self.assertEqual(data["context"], "processamento")
+        self.assertEqual(data["extra_data"], extra_data)
 
     def test_message_builder_missing_required_fields(self):
         builder = MessageBuilder()
         with self.assertRaises(ValueError) as context:
             builder.build()
         self.assertIn("versão e o valor", str(context.exception))
+
+    def test_message_cover_to_json(self):
+        cover = MessageCover(
+            version="v1",
+            value=self.payload,
+            context="ctx",
+            extra_data={"debug": True}
+        )
+        data = json.loads(cover.to_json())
+        self.assertEqual(data["version"], "v1")
+        self.assertEqual(data["value"], self.payload)
+        self.assertEqual(data["context"], "ctx")
+        self.assertEqual(data["extra_data"], {"debug": True})


### PR DESCRIPTION
## Descrição
A lib estava retornando um erro ao instanciar a capa de mensageria no arquivo `message_builder.py`, pois não reconhecia a biblioteca `pydantic`. A solução foi alterar o formato para utilizar apenas a classe pura, sem dependência do pydantic.

## Testes rodando
<img width="878" height="229" alt="image" src="https://github.com/user-attachments/assets/99fd14ac-be2e-4c85-a16a-8a608db0a13f" />
